### PR TITLE
Implement callback messages

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_export_enabled, true}.
 {cover_enabled, true}.
 {deps, [
-        {rocksdb, ".*", {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {branch, "memory-improvements"}}}
+        {rocksdb, ".*", {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {branch, "master"}}}
        ]}.
 
 {dialyzer, [

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
 {cover_export_enabled, true}.
 {cover_enabled, true}.
 {deps, [
-        {rocksdb, ".*", {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {branch, "master"}}}
+        {rocksdb, ".*", {git, "https://gitlab.com/barrel-db/erlang-rocksdb.git", {branch, "memory-improvements"}}}
        ]}.
 
 {dialyzer, [

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"rocksdb">>,
   {git,"https://gitlab.com/barrel-db/erlang-rocksdb.git",
-       {ref,"f81f284a409e1030039125f0690a00bb34cc6b2f"}},
+       {ref,"27ba8402f06e7a446184c70ca2019a5ff3cd1612"}},
   0}].

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,4 @@
 [{<<"rocksdb">>,
   {git,"https://gitlab.com/barrel-db/erlang-rocksdb.git",
-       {ref,"27ba8402f06e7a446184c70ca2019a5ff3cd1612"}},
+       {ref,"8cb18a3a3f3ecd7508ad5b4fd29934212249d3c3"}},
   0}].

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -296,7 +296,7 @@ take(ForActorID, State = #state{bitfieldsize=BitfieldSize, db=DB, module=Module}
                         none ->
                             %% nothing for this actor, flip the bit
                             ActorIDStr = io_lib:format("-~b", [ForActorID+1]),
-                            ok = rocksdb:merge(State#state.db, CF, Key, list_to_binary(ActorIDStr), [{sync, true}]),
+                            ok = rocksdb:merge(State#state.db, CF, Key, list_to_binary(ActorIDStr), []),
                             %% keep looking
                             take(ForActorID, State#state{pending_acks=maps:remove(ForActorID, State#state.pending_acks)});
                         Message ->
@@ -337,7 +337,7 @@ ack(FromActorID, Ref, State = #state{db=DB}) ->
                     %% flip the bit, we can delete it next time we iterate
                     ActorIDStr = io_lib:format("-~b", [FromActorID+1]),
                     ct:pal("merge ~s", [lists:flatten(ActorIDStr)]),
-                    ok = rocksdb:merge(DB, CF, Key, list_to_binary(ActorIDStr), [{sync, true}]);
+                    ok = rocksdb:merge(DB, CF, Key, list_to_binary(ActorIDStr), []);
                 not_found ->
                     %% something strange is happening
                     ok
@@ -653,7 +653,7 @@ find_next_outbound_(ActorID, {ok, <<"o", _/binary>> = Key, <<2:2/integer, Tail/b
                 none ->
                     %% nothing for this actor
                     ActorIDStr = io_lib:format("-~b", [ActorID+1]),
-                    ok = rocksdb:merge(State#state.db, CF, Key, list_to_binary(ActorIDStr), [{sync, true}]),
+                    ok = rocksdb:merge(State#state.db, CF, Key, list_to_binary(ActorIDStr), []),
                     find_next_outbound_(ActorID, cf_iterator_move(Iter, next), Iter, State);
                 Message ->
                     cf_iterator_close(Iter),

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -275,6 +275,7 @@ self_callback_message(_Config) ->
     {false, _} = relcast:command(was_saluted, RC1),
     {ok, RC1_2} = relcast:deliver(<<"salute">>, 2, RC1),
     {ok, Ref,  <<"salutations to 2">>, RC1_3} = relcast:take(2, RC1_2),
+    {ok, Ref,  <<"salutations to 2">>, _} = relcast:take(2, RC1_3),
     {ok, Ref2, <<"salutations to 3">>, RC1_4} = relcast:take(3, RC1_3),
     {ok, RC1_5} = relcast:ack(2, Ref, RC1_4),
     {ok, RC1_6} = relcast:ack(3, Ref2, RC1_5),


### PR DESCRIPTION
The intent with callback messages is to allow per-destination
customization/generation of a multicast-style message. This can be
useful if you have a very similar message sent to all parties that has
some slight differences per destination and want to avoid writing that
message to disk N times.