### PR TITLE
add pipelining to relcast

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ cover:
 	$(REBAR) cover
 
 test: compile
-	$(REBAR) as test do ct --verbose
+	$(REBAR) as test do eunit,ct --verbose
 
 typecheck:
 	$(REBAR) dialyzer

--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -22,7 +22,8 @@
 -record(state,
         {
          counters = [0] :: [pos_integer()],
-         current_counter = 1 :: pos_integer()
+         current_counter = 1 :: pos_integer(),
+         seq = 0 :: non_neg_integer()
         }).
 
 -record(s,
@@ -36,6 +37,7 @@
          inflight = #{} :: #{pos_integer() => [{Seq ::  pos_integer(), Epoch :: non_neg_integer(), binary()}]},
          messages = #{} :: #{{pos_integer(), pos_integer()} => {Epoch :: non_neg_integer(), binary()}},
 
+         seq = [] :: [non_neg_integer()],
          counters = [0] :: [pos_integer()],
          current_counter = 1 :: pos_integer(),
 
@@ -43,6 +45,9 @@
         }).
 
 -define(M, ?MODULE).
+
+-define(PIPELINE_DEPTH, 5).
+-define(MAX_DEFERS, 5).
 
 %% this module describes a simple relcast setup of extremely simple
 %% actors that send and receive random messages.  The actors are
@@ -77,10 +82,13 @@ command(S) ->
     frequency(
       [
        {1, {call, ?M, open, [S#s.actors, S#s.dir]}},
-       {1, {call, ?M, close, [S#s.rc]}},
+       {2, {call, ?M, close, [S#s.rc]}},
+       {1, {call, ?M, stop_command, [S#s.rc]}},
+       {1, {call, ?M, stop_message, [S#s.rc]}},
        {15, {call, ?M, command, [S#s.rc, oneof(S#s.actors), ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
-       {15, {call, ?M, command_multi, [S#s.rc, ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
-       {2, {call, ?M, new_epoch, [S#s.rc]}},
+       {10, {call, ?M, command_multi, [S#s.rc, ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
+       {10, {call, ?M, callback, [S#s.rc, ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
+       {4, {call, ?M, new_epoch, [S#s.rc]}},
 
        {10, {call, ?M, message,
              [S#s.rc,
@@ -89,11 +97,15 @@ command(S) ->
               nat()]}},
        {4, {call, ?M, next_col, [S#s.rc]}}, %% called for model side effects
 
+       {10, {call, ?M, seq_message,
+             [S#s.rc, nat()]}},
+
        {10, {call, ?M, take, [S#s.rc, oneof(S#s.actors)]}},
        {10, {call, ?M, peek, [S#s.rc, oneof(S#s.actors)]}},
+       {5, {call, ?M, in_flight, [S#s.rc, oneof(S#s.actors)]}},
        {10, {call, ?M, ack, [S#s.rc, oneof(S#s.actors), S#s.act_st, S#s.inflight]}},
        {2, {call, ?M, ack_all, [S#s.rc, oneof(S#s.actors), S#s.act_st, S#s.inflight]}},
-       {2, {call, ?M, reset, [S#s.rc, oneof(S#s.actors)]}}
+       {4, {call, ?M, reset, [S#s.rc, oneof(S#s.actors)]}}
       ]).
 
 
@@ -113,7 +125,7 @@ dynamic_precondition(_S, _) ->
 postcondition(S, {call, _, take, [_, Actor]}, R) ->
     MsgInFlight = length(maps:get(Actor, S#s.inflight, [])) + 1,
     #act{acked=Acked} = maps:get(Actor, S#s.act_st),
-    Expected = case MsgInFlight >= 20 of
+    Expected = case MsgInFlight > ?PIPELINE_DEPTH of
                    true ->
                        pipeline_full;
                    false ->
@@ -160,14 +172,45 @@ postcondition(#s{current_counter = MCC,
             counters = SCtrs}, _RC} = relcast:command(state, RC),
     MCC == SCC andalso
         comp_ctrs(inc_counters(Col, Val, MCtrs), SCtrs, MCC);
+postcondition(#s{seq = Seq},
+              {_, _, seq_message, [_RC, Val]}, {_, MySeq, InboundQueue}) ->
+    Values = lists:sort([Val|Seq]),
+    ExpectedSeq = seq_value(lists:usort([Val|Seq]), 0),
+    RemainingValues = [ V || V <- Values, V > MySeq],
+    RemainingValuesInQueue = lists:sort([ N ||  {seq, N} <- [binary_to_term(Bin) || {1, Bin} <- InboundQueue]]),
+    %io:format("Seq ~p MySeq ~p -- ~p~n", [[Val|Seq], MySeq, seq_value(lists:usort([Val|Seq]), 0)]),
+    %io:format("Remaining values ~p~n", [RemainingValues]),
+    %io:format("inbound queue ~p~n", [RemainingValuesInQueue]),
+    case MySeq == ExpectedSeq of
+        false ->
+            {sequence_mismatch, ExpectedSeq, MySeq};
+        true ->
+            case RemainingValues == RemainingValuesInQueue of
+                false ->
+                    {defer_mismatch, RemainingValues, RemainingValuesInQueue};
+                true ->
+                    true
+            end
+    end;
+%% if we're full, don't add anything
+postcondition(_,
+              {_, _, seq_message, [_RC, _Val]}, _) ->
+    true;
+postcondition(S,
+              {_, _, in_flight, [_, Actor]},
+              N) ->
+    #{Actor := Q} = S#s.inflight,
+    length(Q) == N;
 postcondition(_, _, _) ->
     true.
 
 next_state(S, Res, {call, _, open, _}) ->
      S#s{rc = {call, erlang, element, [1, Res]}, dir = {call, erlang, element, [2, Res]}, running = true};
-next_state(S, _, {call, _, close, _}) ->
+next_state(S, _, {call, _, Stop, _}) when Stop == close;
+                                          Stop == stop_command;
+                                          Stop == stop_message ->
     Inf = maps:from_list([{A, []}
-                             || A <- S#s.actors]),
+                          || A <- S#s.actors]),
     S#s{running=false, inflight=Inf};
 next_state(#s{messages = Msgs,
               act_st = States} = S,
@@ -177,7 +220,8 @@ next_state(#s{messages = Msgs,
         act_st = {call, ?M, command_states, [Actor, States]}};
 next_state(#s{messages = Msgs,
               act_st = States} = S,
-           RC, {_, _, command_multi, [_RC0, Msg]}) ->
+           RC, {_, _, Multi, [_RC0, Msg]}) when Multi == command_multi;
+                                                Multi == callback ->
     S#s{rc = RC,
         messages = {call, ?M, command_multi_messages, [States, Msg, Msgs, S#s.epoch]},
         act_st = {call, ?M, command_multi_states, [States]}};
@@ -211,9 +255,14 @@ next_state(S, V, {_, _, take, [_, Actor]}) ->
         inflight = {call, ?M, extract_inf, [V, Actor, S#s.inflight, S#s.messages, S#s.act_st]}};
 next_state(S, _V, {_, _, peek, _}) ->
     S;
+next_state(S, _V, {_, _, in_flight, _}) ->
+    S;
 next_state(S, V, {_, _, message, _}) ->
     S#s{rc = {call, erlang, element, [1, V]},
         counters = {call, ?M, update_counters, [V, S#s.counters]}};
+next_state(S, V, {_, _, seq_message, [_, Seq]}) ->
+    S#s{rc = {call, erlang, element, [1, V]},
+        seq = {call, ?M, update_seq, [Seq, S#s.seq, V]}};
 next_state(S, RC, {_, _, next_col, _}) ->
     S#s{rc = RC,
         current_counter = S#s.current_counter + 1};
@@ -223,6 +272,11 @@ next_state(S, RC, {_, _, reset, [_, Actor]}) ->
 next_state(S, _V, _C) ->
     error({S, _V, _C}),
     S.
+
+update_seq(Seq, Seqs, {_, _, _})->
+    [Seq | Seqs];
+update_seq(_Discard, Seqs, _) ->
+    Seqs.
 
 command_states(Actor, States) ->
     #{Actor := St = #act{sent = Sent}} = States,
@@ -318,13 +372,18 @@ extract_inf({ok, Seq, Msg, _RC}, Actor, Inf, Msgs, States) ->
     {Epoch, _Msg} = maps:get({Actor, length(Q)+Acked + 1}, Msgs),
     Inf#{Actor => Q ++ [{Seq, Epoch, Msg}]}.
 
-update_counters({_, Msg}, Cols0) ->
+update_counters({_RC, Msg}, Cols0) ->
     {add, Col, Val} = binary_to_term(Msg),
     inc_counters(Col, Val, Cols0).
 
 %% -- Commands ---------------------------------------------------------------
 
 open(Actors, Dir0) ->
+    %% make sure that the settings are lowered so we run into more
+    %% edge cases.
+    application:set_env(relcast, max_defers, ?MAX_DEFERS),
+    application:set_env(relcast, pipeline_depth, ?PIPELINE_DEPTH),
+
     Dir = case Dir0 of
               undefined ->
                   DirNum = erlang:unique_integer(),
@@ -340,12 +399,24 @@ open(Actors, Dir0) ->
 close(RC) ->
     relcast:stop(reason, RC).
 
+stop_command(RC) ->
+    {stop, ok, 0, RC1} = relcast:command(stop, RC),
+    relcast:stop(reason, RC1).
+
+stop_message(RC) ->
+    {stop, 0, RC1} = relcast:deliver(term_to_binary(stop), 1, RC),
+    relcast:stop(reason, RC1).
+
 command(RC, Actor, Msg) ->
     {ok, RC1} = relcast:command({Actor, Msg}, RC),
     RC1.
 
 command_multi(RC,  Msg) ->
     {ok, RC1} = relcast:command({all, Msg}, RC),
+    RC1.
+
+callback(RC,  Msg) ->
+    {ok, RC1} = relcast:command({callback, Msg}, RC),
     RC1.
 
 new_epoch(RC) ->
@@ -358,10 +429,8 @@ take(RC, Actor) ->
 peek(RC, Actor) ->
     relcast:peek(Actor, RC).
 
-%% note that this simulates a deliver to a remote actor; we never
-%% actually make or deliver any messages to the local relcast instance.
-deliver(_Actor) ->
-    ok.
+in_flight(RC, Actor) ->
+    relcast:in_flight(Actor, RC).
 
 ack(RC, Actor, States, InFlight) ->
     #{Actor := State} = States,
@@ -392,7 +461,7 @@ ack_all(RC, Actor, States, InFlight) ->
                     RC1 = RC;
                 true ->
                     {Seq, _Epoch, _Msg} = lists:last(OurInFlight),
-                    {ok, RC1} = relcast:ack(Actor, Seq, RC)
+                    {ok, RC1} = relcast:multi_ack(Actor, Seq, RC)
             end
     end,
     RC1.
@@ -410,6 +479,17 @@ next_col(RC) ->
     {ok, RC1} = relcast:command(next_col, RC),
     RC1.
 
+seq_message(RC, Seq) ->
+    Msg = term_to_binary({seq, Seq}),
+    case relcast:deliver(Msg, 1, RC) of
+        {ok, RC1} ->
+            {#state{seq=MySeq}, RC2} = relcast:command(state, RC1),
+            {_Ms, InboundQueue, _OutboundQueue} = relcast:status(RC2),
+            {RC2, MySeq, InboundQueue};
+        full ->
+            {RC}
+    end.
+
 cleanup(#s{rc=undefined}) ->
     true;
 cleanup(#s{rc=RC, dir=Dir, running=Running}) ->
@@ -426,7 +506,7 @@ cleanup(#s{rc=RC, dir=Dir, running=Running}) ->
 prop_basic() ->
     ?FORALL(
        %% default to longer commands sequences for better coverage
-       Cmds, more_commands(2, commands(?M)),
+       Cmds, more_commands(5, commands(?M)),
        with_parameters(
          [{show_states, false},  % make true to print state at each transition
           {print_counterexample, true}],
@@ -462,10 +542,14 @@ bugs(Time, Bugs) ->
 init(_) ->
     {ok, #state{}}.
 
+handle_command(stop, State) ->
+    {reply, ok, [{stop, 0}], State};
 handle_command(new_epoch, State) ->
     {reply, ok, [new_epoch], State};
 handle_command({all, Msg}, State) ->
     {reply, ok, [{multicast, Msg}], State};
+handle_command({callback, Msg}, State) ->
+    {reply, ok, [{callback, Msg}], State};
 handle_command(state, State) ->
     {reply, State, ignore};
 handle_command(next_col, #state{current_counter = CC} = State) ->
@@ -485,12 +569,20 @@ restore(_A, #state{} = B) ->
     {ok, B}.
 
 handle_message(Msg, _From, #state{current_counter = CC,
-                                  counters = Counters} = State) ->
+                                  counters = Counters, seq=MySeq} = State) ->
     case catch binary_to_term(Msg) of
         {add, Col, _Val} when Col > CC ->
             defer;
         {add, Col, Val} ->
             {State#state{counters = inc_counters(Col, Val, Counters)}, []};
+        {seq, Seq} when Seq =< MySeq ->
+            ignore;
+        {seq, Seq} when Seq == (MySeq + 1) ->
+            {State#state{seq=Seq}, []};
+        {seq, _Seq} ->
+            defer;
+        stop ->
+            {State, [{stop, 0}]};
         %% multicast crap also ends up here, which will feed us garbage
         _ ->
             ignore
@@ -498,8 +590,12 @@ handle_message(Msg, _From, #state{current_counter = CC,
 handle_message(_, _, _) ->
     ignore.
 
-callback_message(_, _, _) ->
-    ignore.
+callback_message(_ToActor, Message, _State) ->
+    Message.
+
+%% juice that coverage!
+terminate(_, _) ->
+    ok.
 
 %%% helpers
 
@@ -537,21 +633,21 @@ comp_ctrs(Model, State, Column) ->
                        true ->
                            Ct + 1;
                        false ->
-                           {defer, {mod, Model}, {state, State}}
+                           {defer, Column, {mod, Model}, {state, State}}
                    end;
               ({M, S}, Ct) when Ct == Column ->
                    case M >= S of
                        true ->
                            Ct + 1;
                        false ->
-                           {defer1, {mod, Model}, {state, State}}
+                           {defer1, Column, {mod, Model}, {state, State}}
                    end;
               ({_M, S}, Ct) ->
                    case S == 0 of
                        true ->
                            Ct + 1;
                        false ->
-                           {defer2, {mod, Model}, {state, State}}
+                           {defer2, Column, {mod, Model}, {state, State}}
                    end
            end,
            1,
@@ -561,3 +657,10 @@ comp_ctrs(Model, State, Column) ->
         Else ->
             Else
     end.
+
+seq_value([H|T], Acc) when H =< Acc ->
+    seq_value(T, Acc);
+seq_value([H|T], Acc) when H == Acc + 1 ->
+    seq_value(T, H);
+seq_value(_, Acc) ->
+    Acc.

--- a/rebar.config
+++ b/rebar.config
@@ -14,10 +14,10 @@
   %% rebar3_eqc
  ]}.
 
-{eqc_opts, [{dir, "test"}]}.
-
 {cover_export_enabled, true}.
 {cover_enabled, true}.
+{cover_opts, [{verbose, true}]}.
+{cover_excl_mods, [fakecast, basic_SUITE, basic_eqc, test_handler]}.
 
 {deps, [
         lager,

--- a/rebar.config
+++ b/rebar.config
@@ -1,10 +1,29 @@
-{erl_opts, [debug_info, warn_untyped_record, warnings_as_errors]}.
+%% -*- erlang -*-
+
+{erl_opts,
+ [
+  {parse_transform, lager_transform},
+  debug_info,
+  warn_untyped_record,
+  warnings_as_errors
+ ]}.
+
+{project_plugins,
+ [
+  {rebar3_eqc, {git, "https://github.com/Vagabond/rebar3-eqc-plugin", {branch, "master"}}}
+  %% rebar3_eqc
+ ]}.
+
+{eqc_opts, [{dir, "test"}]}.
 
 {cover_export_enabled, true}.
 {cover_enabled, true}.
+
 {deps, [
-    {rocksdb, ".*", {git, "https://gitlab.com/Vagabond1/erlang-rocksdb.git", {branch, "adt/open_with_ttl"}}}
-]}.
+        lager,
+        {rocksdb, ".*", {git, "https://gitlab.com/Vagabond1/erlang-rocksdb.git", {branch, "adt/open_with_ttl"}}}
+       ]
+}.
 
 {dialyzer, [
             {warnings, [unknown]},

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,4 +1,12 @@
-[{<<"rocksdb">>,
+{"1.1.0",
+[{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0},
+ {<<"rocksdb">>,
   {git,"https://gitlab.com/Vagabond1/erlang-rocksdb.git",
        {ref,"e74d055756addd675ac83f6981c83c02974a6959"}},
-  0}].
+  0}]}.
+[
+{pkg_hash,[
+ {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>}]}
+].

--- a/src/relcast.app.src
+++ b/src/relcast.app.src
@@ -7,7 +7,11 @@
     stdlib,
     rocksdb
    ]},
-  {env,[]},
+  {env,
+   [
+    {pipeline_depth, 20},
+    {max_defers, 100}
+   ]},
   {modules, []},
 
   {maintainers, []},

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -209,7 +209,7 @@ epochs(_Config) ->
     {ok, _Ref2, <<"hai">>, RC1_9} = relcast:take(2, RC1_8),
     relcast:stop(normal, RC1_9),
     {ok, CFs} = rocksdb:list_column_families("data5", []),
-    ["default", "epoch0000000000", "epoch0000000001"] = CFs,
+    ["default", "Inbound", "epoch0000000000", "epoch0000000001"] = CFs,
     %% reopen the relcast and make sure it didn't delete any wrong column
     %% families
     {ok, RC1_10} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data6"}]),
@@ -235,18 +235,18 @@ epochs_gc(_Config) ->
     {ok, RC1_6} = relcast:command(next_round, RC1_5),
     %% check the deferred message from the previous epoch gets handled
     {Map, _} = relcast:command(seqmap, RC1_6),
-    [] = maps:to_list(Map),
+    [{2, 1}] = maps:to_list(Map),
     %% go to the next round
     {ok, RC1_7} = relcast:command(next_round, RC1_6),
     {2, _} = relcast:command(round, RC1_7),
     %% check the deferred message from the previous epoch gets handled
     {Map2, _} = relcast:command(seqmap, RC1_7),
-    [] = maps:to_list(Map2),
+    [{2, 2}] = maps:to_list(Map2),
     %% the data from the original epoch has been GC'd
     {not_found, _} = relcast:take(2, RC1_7),
     relcast:stop(normal, RC1_7),
     {ok, CFs} = rocksdb:list_column_families("data6", []),
-    ["default", "epoch0000000001", "epoch0000000002"] = CFs,
+    ["default", "Inbound", "epoch0000000001", "epoch0000000002"] = CFs,
     %% reopen the relcast and make sure it didn't delete any wrong column
     %% families
     {ok, RC1_10} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data6"}]),
@@ -255,6 +255,7 @@ epochs_gc(_Config) ->
     %% Re-add the old epoch 0 CF and check it gets removed
     {ok, DB, _} = rocksdb:open_with_cf("data6", [{create_if_missing, true}],
                                        [{"default", []},
+                                        {"Inbound", []},
                                         {"epoch0000000001", []},
                                         {"epoch0000000002", []}]),
     {ok, _Epoch0} = rocksdb:create_column_family(DB, "epoch0000000000", []),
@@ -263,8 +264,9 @@ epochs_gc(_Config) ->
     relcast:stop(normal, RC1_11),
     {ok, CFs} = rocksdb:list_column_families("data6", []),
     %% delete epoch 1, re-add epoch 0 and check 0 is pruned again because it's non-contiguous
-    {ok, DB2, [_, Epoch1, _]} = rocksdb:open_with_cf("data6", [{create_if_missing, true}],
+    {ok, DB2, [_, _, Epoch1, _]} = rocksdb:open_with_cf("data6", [{create_if_missing, true}],
                                        [{"default", []},
+                                        {"Inbound", []},
                                         {"epoch0000000001", []},
                                         {"epoch0000000002", []}]),
     {ok, _} = rocksdb:create_column_family(DB2, "epoch0000000000", []),
@@ -272,7 +274,7 @@ epochs_gc(_Config) ->
     rocksdb:close(DB2),
     {ok, RC1_12} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data6"}]),
     relcast:stop(normal, RC1_12),
-    {ok, ["default", "epoch0000000002"]} = rocksdb:list_column_families("data6", []),
+    {ok, ["default", "Inbound", "epoch0000000002"]} = rocksdb:list_column_families("data6", []),
     ok.
 
 callback_message(_Config) ->
@@ -314,9 +316,10 @@ epoch_no_state(_Config) ->
     {0, _} = relcast:command(round, RC1_2),
     relcast:stop(normal, RC1_2),
     {ok, CFs} = rocksdb:list_column_families("data10", []),
-    ["default", "epoch0000000000"] = CFs,
+    ["default","Inbound",  "epoch0000000000"] = CFs,
     {ok, DB, _} = rocksdb:open_with_cf("data10", [{create_if_missing, true}],
                                        [{"default", []},
+                                        {"Inbound", []},
                                         {"epoch0000000000", []}]),
     {ok, Epoch1} = rocksdb:create_column_family(DB, "epoch0000000001", []),
     not_found = rocksdb:get(DB, Epoch1, <<"stored_module_state">>, []),
@@ -324,9 +327,10 @@ epoch_no_state(_Config) ->
     {ok, RC2} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data10"}]),
     relcast:stop(normal, RC2),
     {ok, CFs2} = rocksdb:list_column_families("data10", []),
-    ["default", "epoch0000000000", "epoch0000000001"] = CFs2,
-    {ok, DB2, [_, _, CF1]} = rocksdb:open_with_cf("data10", [{create_if_missing, true}],
+    ["default", "Inbound", "epoch0000000000", "epoch0000000001"] = CFs2,
+    {ok, DB2, [_, _, _, CF1]} = rocksdb:open_with_cf("data10", [{create_if_missing, true}],
                                        [{"default", []},
+                                        {"Inbound", []},
                                         {"epoch0000000000", []},
                                         {"epoch0000000001", []}]),
     {ok, _Result} = rocksdb:get(DB2, CF1, <<"stored_module_state">>, []),
@@ -342,24 +346,37 @@ pipeline(_Config) ->
                     end,
                     {ok, RC1},
                     [N || N <- lists:seq(1, 30)]),
-    {ok, Ref, <<"hello - 20">>, RC3} =
+    {ok, Ref1, <<"hello - 18">>, RC3} =
         lists:foldl(fun(_Idx, {ok, _R, _Msg, Acc}) ->
                             relcast:take(2, Acc)
                     end,
                     {ok, ign, ign, RC2},
-                    [N || N <- lists:seq(1, 20)]),
-    {pipeline_full, _RC3} = relcast:take(2, RC3),
+                    [N || N <- lists:seq(1, 18)]),
+    {ok, Ref2, <<"hello - 19">>, RC4} = relcast:take(2, RC3),
+    {ok, Ref3, <<"hello - 20">>, RC5} = relcast:take(2, RC4),
+    {pipeline_full, _RC4} = relcast:take(2, RC5),
+    20 = relcast:in_flight(2, RC5),
+    %% singly ack the second-to-last message first
+    {ok, RC6} = relcast:ack(2, Ref2, RC5),
+    19 = relcast:in_flight(2, RC6),
     %% test multi-ack
-    {ok, RC4} = relcast:ack(2, Ref, RC3),
+    {ok, RC7} = relcast:multi_ack(2, Ref1, RC6),
+    1 = relcast:in_flight(2, RC7),
+    %% ack the last message singly
+    {ok, RC8} = relcast:ack(2, Ref3, RC7),
+    0 = relcast:in_flight(2, RC8),
     %% test single acks
-    RC5 =
+    RC9 =
         lists:foldl(fun(Idx, Acc) ->
                             Msg = <<"hello - ", (integer_to_binary(Idx))/binary>>,
+                            0 = relcast:in_flight(2, Acc),
                             {ok, R, Msg, Acc1} = relcast:take(2, Acc),
-                            {ok, Acc2} = relcast:ack(R, 2, Acc1),
+                            1 = relcast:in_flight(2, Acc1),
+                            {ok, Acc2} = relcast:ack(2, R, Acc1),
+                            0 = relcast:in_flight(2, Acc2),
                             Acc2
                     end,
-                    RC4,
+                    RC8,
                     [N || N <- lists:seq(21, 30)]),
-    {not_found, _} = relcast:take(2, RC5),
+    {not_found, _} = relcast:take(2, RC9),
     ok.

--- a/test/basic_eqc.erl
+++ b/test/basic_eqc.erl
@@ -1,0 +1,563 @@
+-module(basic_eqc).
+
+-include_lib("eqc/include/eqc.hrl").
+-include_lib("eqc/include/eqc_statem.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+-behaviour(eqc_statem).
+-behaviour(relcast).
+
+%% -- State and state functions ----------------------------------------------
+
+-record(act,
+        {
+         id :: non_neg_integer(),
+         sent = 0 :: non_neg_integer(),
+         acked = 0 :: non_neg_integer()
+        }).
+
+-type act() :: #act{}.
+
+-record(state,
+        {
+         counters = [0] :: [pos_integer()],
+         current_counter = 1 :: pos_integer()
+        }).
+
+-record(s,
+        {
+         rc :: term(),
+         epoch = 1 :: non_neg_integer(),
+         dir :: string(),
+         actors :: [pos_integer()],
+         act_st = #{} :: #{pos_integer() => act()},
+         %% TODO should we move in-flight into the actor?
+         inflight = #{} :: #{pos_integer() => [{Seq ::  pos_integer(), Epoch :: non_neg_integer(), binary()}]},
+         messages = #{} :: #{{pos_integer(), pos_integer()} => {Epoch :: non_neg_integer(), binary()}},
+
+         counters = [0] :: [pos_integer()],
+         current_counter = 1 :: pos_integer(),
+
+         running = false :: boolean()
+        }).
+
+-define(M, ?MODULE).
+
+%% this module describes a simple relcast setup of extremely simple
+%% actors that send and receive random messages.  The actors are
+%% virtual, in that they don't have any pids themselves, hence no
+%% nondeterminism.  Todos:
+%%  - two relcast instances talking to each other (if possible in the
+%%    same VM)
+%%  - PULSE test
+%%  - non-virtual actors expressing some simple protocol
+
+%% @doc Returns the state in which each test case starts. (Unless a different
+%%      initial state is supplied explicitly to, e.g. commands/2.)
+-spec initial_state() -> eqc_statem:symbolic_state().
+initial_state() ->
+    Actors = lists:seq(2, 4),
+
+    States = maps:from_list([{A, #act{id = A}}
+                             || A <- Actors]),
+
+    Inf = maps:from_list([{A, []}
+                             || A <- Actors]),
+
+    #s{actors = Actors,
+       rc = undefined,
+       inflight = Inf,
+       running = true,
+       act_st = States}.
+
+%% -- Generators -------------------------------------------------------------
+
+command(S) ->
+    frequency(
+      [
+       {1, {call, ?M, open, [S#s.actors, S#s.dir]}},
+       {1, {call, ?M, close, [S#s.rc]}},
+       {15, {call, ?M, command, [S#s.rc, oneof(S#s.actors), ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
+       {15, {call, ?M, command_multi, [S#s.rc, ?SUCHTHAT(X, binary(), byte_size(X) > 0)]}},
+       {2, {call, ?M, new_epoch, [S#s.rc]}},
+
+       {10, {call, ?M, message,
+             [S#s.rc,
+              oneof(S#s.actors),
+              oneof(lists:seq(S#s.current_counter, S#s.current_counter + 2)),
+              nat()]}},
+       {4, {call, ?M, next_col, [S#s.rc]}}, %% called for model side effects
+
+       {10, {call, ?M, take, [S#s.rc, oneof(S#s.actors)]}},
+       {10, {call, ?M, peek, [S#s.rc, oneof(S#s.actors)]}},
+       {10, {call, ?M, ack, [S#s.rc, oneof(S#s.actors), S#s.act_st, S#s.inflight]}},
+       {2, {call, ?M, ack_all, [S#s.rc, oneof(S#s.actors), S#s.act_st, S#s.inflight]}},
+       {2, {call, ?M, reset, [S#s.rc, oneof(S#s.actors)]}}
+      ]).
+
+
+precondition(S, {call, _, open, _}) ->
+     S#s.rc == undefined orelse S#s.running == false;
+precondition(S, {call, _, close, _}) ->
+    S#s.rc /= undefined andalso S#s.running == true;
+precondition(S, _) ->
+    S#s.rc /= undefined andalso S#s.running == true.
+
+dynamic_precondition(_S, {_, _, ack, [_, Actor, _, Inf]}) ->
+    #{Actor := Q} = Inf,
+    Q /= [];
+dynamic_precondition(_S, _) ->
+    true.
+
+postcondition(S, {call, _, take, [_, Actor]}, R) ->
+    MsgInFlight = length(maps:get(Actor, S#s.inflight, [])) + 1,
+    #act{acked=Acked} = maps:get(Actor, S#s.act_st),
+    Expected = case MsgInFlight >= 20 of
+                   true ->
+                       pipeline_full;
+                   false ->
+                       {_Epoch, Msg} = maps:get({Actor, MsgInFlight+Acked}, S#s.messages, {0, not_found}),
+                       Msg
+               end,
+
+    case R of
+        {ok, _Seq, Expected, _RC} ->
+            true;
+        {Expected, _RC} ->
+            true;
+        {ok, _Seq, Unexpected, _RC} ->
+            {unexpected_take1, Actor, Expected, Unexpected, S#s.messages, S#s.inflight};
+        {Unexpected, _RC} ->
+            {unexpected_take2, Actor, Expected, Unexpected, S#s.messages, S#s.inflight}
+    end;
+postcondition(S, {call, _, peek, [_, Actor]}, R) ->
+    MsgInFlight = length(maps:get(Actor, S#s.inflight, [])) + 1,
+    #act{acked = Acked} = maps:get(Actor, S#s.act_st),
+    Expected =
+        case maps:get({Actor, MsgInFlight+Acked}, S#s.messages, not_found) of
+            {_Epoch, Msg} ->
+                Msg;
+            Else ->
+                Else
+        end,
+    case R of
+        Expected ->
+            true;
+        {ok, Expected}->
+            true;
+        {ok, Unexpected}->
+            {unexpected_peek, Actor, {exp, Expected}, {got, Unexpected},
+             S#s.messages, S#s.inflight};
+        Unexpected->
+            {unexpected_peek2, Actor, {exp, Expected}, {got, Unexpected},
+             S#s.messages, S#s.inflight}
+    end;
+postcondition(#s{current_counter = MCC,
+                 counters = MCtrs},
+              {_, _, message, [RC, _, Col, Val]}, _R) ->
+    {#state{current_counter = SCC,
+            counters = SCtrs}, _RC} = relcast:command(state, RC),
+    MCC == SCC andalso
+        comp_ctrs(inc_counters(Col, Val, MCtrs), SCtrs, MCC);
+postcondition(_, _, _) ->
+    true.
+
+next_state(S, Res, {call, _, open, _}) ->
+     S#s{rc = {call, erlang, element, [1, Res]}, dir = {call, erlang, element, [2, Res]}, running = true};
+next_state(S, _, {call, _, close, _}) ->
+    Inf = maps:from_list([{A, []}
+                             || A <- S#s.actors]),
+    S#s{running=false, inflight=Inf};
+next_state(#s{messages = Msgs,
+              act_st = States} = S,
+           RC, {_, _, command, [_RC0, Actor, Msg]}) ->
+    S#s{rc = RC,
+        messages = {call, ?M, command_messages, [Actor, States, Msg, Msgs, S#s.epoch]},
+        act_st = {call, ?M, command_states, [Actor, States]}};
+next_state(#s{messages = Msgs,
+              act_st = States} = S,
+           RC, {_, _, command_multi, [_RC0, Msg]}) ->
+    S#s{rc = RC,
+        messages = {call, ?M, command_multi_messages, [States, Msg, Msgs, S#s.epoch]},
+        act_st = {call, ?M, command_multi_states, [States]}};
+next_state(#s{messages = Msgs,
+              act_st = States,
+              inflight = InFlight,
+              epoch = Epoch} = S,
+           RC, {_, _, new_epoch, [_RC0]}) ->
+    S#s{rc = RC, epoch = Epoch + 1,
+        inflight = {call, ?M, filter_old_inflight, [InFlight, Epoch + 1]},
+        act_st = {call, ?M, filter_old_states, [States, Msgs, Epoch + 1]}};
+next_state(#s{act_st = States, inflight=InFlight} = S,
+           RC,
+           {_, _, ack, [_, Actor, _, _]}) ->
+    S#s{rc = RC,
+        act_st = {call, ?M, ack_states, [Actor, States, InFlight]},
+        inflight = {call, ?M, deliver_inf, [Actor, InFlight]}};
+next_state(#s{act_st = States, inflight = InFlight} = S,
+           RC,
+           {_, _, ack_all, [_, Actor, _, _]}) ->
+    S#s{rc = RC,
+        act_st = {call, ?M, ack_all_states, [Actor, States, InFlight]},
+        inflight = {call, ?M, reset_inf, [Actor, InFlight]}};
+next_state(#s{act_st = States,
+              inflight = Inf} = S,
+           _V, {_, _, deliver, [Actor]}) ->
+    S#s{act_st = {call, ?M, deliver_st, [Inf, Actor, States]},
+        inflight = {call, ?M, deliver_inf, [Actor, Inf]}};
+next_state(S, V, {_, _, take, [_, Actor]}) ->
+    S#s{rc = {call, ?M, extract_state, [V]},
+        inflight = {call, ?M, extract_inf, [V, Actor, S#s.inflight, S#s.messages, S#s.act_st]}};
+next_state(S, _V, {_, _, peek, _}) ->
+    S;
+next_state(S, V, {_, _, message, _}) ->
+    S#s{rc = {call, erlang, element, [1, V]},
+        counters = {call, ?M, update_counters, [V, S#s.counters]}};
+next_state(S, RC, {_, _, next_col, _}) ->
+    S#s{rc = RC,
+        current_counter = S#s.current_counter + 1};
+next_state(S, RC, {_, _, reset, [_, Actor]}) ->
+    S#s{rc = RC,
+        inflight = {call, ?M, reset_inf, [Actor, S#s.inflight]}};
+next_state(S, _V, _C) ->
+    error({S, _V, _C}),
+    S.
+
+command_states(Actor, States) ->
+    #{Actor := St = #act{sent = Sent}} = States,
+    States#{Actor => St#act{sent = Sent + 1}}.
+
+command_messages(Actor, States, Msg, Msgs, Epoch) ->
+    #{Actor := #act{sent = Sent}} = States,
+    Msgs#{{Actor, Sent + 1} => {Epoch, Msg}}.
+
+command_multi_states(States) ->
+    maps:map(fun(_, State = #act{sent=Sent}) -> State#act{sent = Sent + 1} end, States).
+
+command_multi_messages(States, Msg, Msgs, Epoch) ->
+    maps:fold(fun(Actor, #act{sent=Sent}, Acc) -> Acc#{{Actor, Sent + 1} => {Epoch, Msg}} end, Msgs, States).
+
+ack_states(Actor, States, InFlight) ->
+    MyInFlight = maps:get(Actor, InFlight),
+    #{Actor := State} = States,
+    case State of
+        #act{sent = Sent, acked = Acked} when Sent == Acked ->
+            States;
+        #act{acked = Acked} when length(MyInFlight) > 0 ->
+            States#{Actor => State#act{acked = Acked + 1}};
+        _ ->
+            States
+    end.
+
+ack_all_states(Actor, States, InFlight) ->
+    MyInFlight = maps:get(Actor, InFlight),
+    #{Actor := State} = States,
+    case State of
+        #act{sent = Sent, acked = Acked} when Sent == Acked ->
+            States;
+        #act{acked = Acked} when length(MyInFlight) > 0 ->
+            States#{Actor => State#act{acked = Acked + length(MyInFlight)}};
+        _ ->
+            States
+    end.
+
+deliver_st(Inf, Actor, States) ->
+    case Inf of
+        #{Actor := [_H|_T]} ->
+            #{Actor := #act{sent = Sent} = State} = States,
+            States#{Actor => State#act{sent = Sent + 1}};
+        _ ->
+            States
+    end.
+
+deliver_inf(Actor, Inf) ->
+    case Inf of
+        #{Actor := [_H|T]} ->
+            Inf#{Actor => T};
+        _ ->
+            Inf
+    end.
+
+filter_old_states(States, Msgs, Epoch) ->
+    maps:map(fun(Actor, State = #act{sent=Sent, acked=Acked}) ->
+                     %% first figure out how many old messages there are for this actor
+                    OldMsgCount = maps:fold(fun({A, _}, {MEpoch, _}, Acc) when Actor == A ->
+                                                     case MEpoch < Epoch - 1 of
+                                                         true ->
+                                                             Acc + 1;
+                                                         false ->
+                                                             Acc
+                                                     end;
+                                                (_, _, Acc) ->
+                                                     Acc
+                                             end, 0, Msgs),
+                    %% the new ack count is at minimum the number of old messages
+                     State#act{sent = Sent, acked = max(Acked, OldMsgCount) }
+             end, States).
+
+filter_old_inflight(InFlight, Epoch) ->
+    maps:map(fun(_, V) ->
+                     lists:filter(fun({_Seq, E, _Msg}) -> E > Epoch - 2 end, V)
+             end, InFlight).
+
+reset_inf(Actor, Inf) ->
+    Inf#{Actor => []}.
+
+extract_state({_, RC}) ->
+    RC;
+extract_state({ok, _, _, RC}) ->
+    RC.
+
+extract_inf({_, _}, _, Inf, _, _) ->
+    Inf;
+extract_inf({ok, Seq, Msg, _RC}, Actor, Inf, Msgs, States) ->
+    %% find which epoch this message was from
+    #act{acked = Acked} = maps:get(Actor, States),
+    #{Actor := Q} = Inf,
+    {Epoch, _Msg} = maps:get({Actor, length(Q)+Acked + 1}, Msgs),
+    Inf#{Actor => Q ++ [{Seq, Epoch, Msg}]}.
+
+update_counters({_, Msg}, Cols0) ->
+    {add, Col, Val} = binary_to_term(Msg),
+    inc_counters(Col, Val, Cols0).
+
+%% -- Commands ---------------------------------------------------------------
+
+open(Actors, Dir0) ->
+    Dir = case Dir0 of
+              undefined ->
+                  DirNum = erlang:unique_integer(),
+                  D = "data/data-" ++ integer_to_list(DirNum),
+                  os:cmd("rm -rf "++D),
+                  D;
+              Dir0 ->
+                  Dir0
+          end,
+    {ok, RC} = relcast:start(1, [1 | Actors], ?M, #state{}, [{data_dir, Dir}]),
+    {RC, Dir}.
+
+close(RC) ->
+    relcast:stop(reason, RC).
+
+command(RC, Actor, Msg) ->
+    {ok, RC1} = relcast:command({Actor, Msg}, RC),
+    RC1.
+
+command_multi(RC,  Msg) ->
+    {ok, RC1} = relcast:command({all, Msg}, RC),
+    RC1.
+
+new_epoch(RC) ->
+    {ok, RC1} = relcast:command(new_epoch, RC),
+    RC1.
+
+take(RC, Actor) ->
+    relcast:take(Actor, RC).
+
+peek(RC, Actor) ->
+    relcast:peek(Actor, RC).
+
+%% note that this simulates a deliver to a remote actor; we never
+%% actually make or deliver any messages to the local relcast instance.
+deliver(_Actor) ->
+    ok.
+
+ack(RC, Actor, States, InFlight) ->
+    #{Actor := State} = States,
+    case State of
+        #act{sent = Sent, acked = Acked} when Sent == Acked ->
+            RC1 = RC;
+        _ ->
+            OurInFlight = maps:get(Actor, InFlight),
+            case length(OurInFlight) > 0 of
+                false ->
+                    RC1 = RC;
+                true ->
+                    {Seq, _Epoch, _Msg} = hd(OurInFlight),
+                    {ok, RC1} = relcast:ack(Actor, Seq, RC)
+            end
+    end,
+    RC1.
+
+ack_all(RC, Actor, States, InFlight) ->
+    #{Actor := State} = States,
+    case State of
+        #act{sent = Sent, acked = Acked} when Sent == Acked ->
+            RC1 = RC;
+        _ ->
+            OurInFlight = maps:get(Actor, InFlight),
+            case length(OurInFlight) > 0 of
+                false ->
+                    RC1 = RC;
+                true ->
+                    {Seq, _Epoch, _Msg} = lists:last(OurInFlight),
+                    {ok, RC1} = relcast:ack(Actor, Seq, RC)
+            end
+    end,
+    RC1.
+
+reset(RC, Actor) ->
+    {ok, RC1} = relcast:reset_actor(Actor, RC),
+    RC1.
+
+message(RC, FromActor, Col, Val) ->
+    Msg = term_to_binary({add, Col, Val}),
+    {ok, RC1} = relcast:deliver(Msg, FromActor, RC),
+    {RC1, Msg}.
+
+next_col(RC) ->
+    {ok, RC1} = relcast:command(next_col, RC),
+    RC1.
+
+cleanup(#s{rc=undefined}) ->
+    true;
+cleanup(#s{rc=RC, dir=Dir, running=Running}) ->
+    case Running of
+        true ->
+            catch relcast:stop(reason, RC);
+        false ->
+            ok
+    end,
+    os:cmd("rm -rf " ++ Dir),
+    true.
+
+%% -- Property ---------------------------------------------------------------
+prop_basic() ->
+    ?FORALL(
+       %% default to longer commands sequences for better coverage
+       Cmds, more_commands(2, commands(?M)),
+       with_parameters(
+         [{show_states, false},  % make true to print state at each transition
+          {print_counterexample, true}],
+         aggregate(command_names(Cmds),
+           begin
+               {H, S, Res} = run_commands(Cmds),
+               eqc_statem:pretty_commands(?M,
+                                          Cmds,
+                                          {H, S, Res},
+                                          cleanup(eqc_symbolic:eval(S))
+                                          andalso Res == ok)
+           end))).
+
+%% @doc Run property repeatedly to find as many different bugs as
+%% possible. Runs for 10 seconds before giving up finding more bugs.
+-spec bugs() -> [eqc_statem:bug()].
+bugs() -> bugs(10).
+
+%% @doc Run property repeatedly to find as many different bugs as
+%% possible. Runs for N seconds before giving up finding more bugs.
+-spec bugs(non_neg_integer()) -> [eqc_statem:bug()].
+bugs(N) -> bugs(N, []).
+
+%% @doc Run property repeatedly to find as many different bugs as
+%% possible. Takes testing time and already found bugs as arguments.
+-spec bugs(non_neg_integer(), [eqc_statem:bug()]) -> [eqc_statem:bug()].
+bugs(Time, Bugs) ->
+    more_bugs(eqc:testing_time(Time, prop_basic()), 20, Bugs).
+
+
+%% local relcast impl
+
+init(_) ->
+    {ok, #state{}}.
+
+handle_command(new_epoch, State) ->
+    {reply, ok, [new_epoch], State};
+handle_command({all, Msg}, State) ->
+    {reply, ok, [{multicast, Msg}], State};
+handle_command(state, State) ->
+    {reply, State, ignore};
+handle_command(next_col, #state{current_counter = CC} = State) ->
+    {reply, ok, [], State#state{current_counter = CC + 1}};
+handle_command({Actor, Msg}, State) ->
+    {reply, ok, [{unicast, Actor, Msg}], State}.
+
+serialize(Foo) ->
+    term_to_binary(Foo).
+
+deserialize(Foo) ->
+    binary_to_term(Foo).
+
+restore(#state{} = A, _B) ->
+    {ok, A};
+restore(_A, #state{} = B) ->
+    {ok, B}.
+
+handle_message(Msg, _From, #state{current_counter = CC,
+                                  counters = Counters} = State) ->
+    case catch binary_to_term(Msg) of
+        {add, Col, _Val} when Col > CC ->
+            defer;
+        {add, Col, Val} ->
+            {State#state{counters = inc_counters(Col, Val, Counters)}, []};
+        %% multicast crap also ends up here, which will feed us garbage
+        _ ->
+            ignore
+    end;
+handle_message(_, _, _) ->
+    ignore.
+
+callback_message(_, _, _) ->
+    ignore.
+
+%%% helpers
+
+inc_counters(Col, Val, Cols0) ->
+    Len = Col - length(Cols0),
+    Cols =
+        case Len > 0 of
+            true ->
+                Zeros = lists:duplicate(Len, 0),
+                lists:append(Cols0, Zeros);
+            false -> Cols0
+        end,
+    {_, Cols1r} =
+        lists:foldl(fun(Elt, {Ctr, Acc}) when Ctr == Col ->
+                            {Ctr + 1, [Elt + Val | Acc]};
+                       (Elt, {Ctr, Acc}) ->
+                            {Ctr + 1, [Elt | Acc]}
+                    end, {1, []}, Cols),
+    lists:reverse(Cols1r).
+
+comp_ctrs(Model, State, Column) ->
+    Comp =
+        case length(Model) == length(State) of
+            true ->
+                lists:zip(Model, State);
+            _ ->
+                {M1, _} = lists:split(length(State), Model),
+                lists:zip(M1, State)
+        end,
+    case lists:foldl(
+           fun(_, Tup) when is_tuple(Tup) ->
+                   Tup;
+              ({M, S}, Ct) when Ct < Column ->
+                   case M == S of
+                       true ->
+                           Ct + 1;
+                       false ->
+                           {defer, {mod, Model}, {state, State}}
+                   end;
+              ({M, S}, Ct) when Ct == Column ->
+                   case M >= S of
+                       true ->
+                           Ct + 1;
+                       false ->
+                           {defer1, {mod, Model}, {state, State}}
+                   end;
+              ({_M, S}, Ct) ->
+                   case S == 0 of
+                       true ->
+                           Ct + 1;
+                       false ->
+                           {defer2, {mod, Model}, {state, State}}
+                   end
+           end,
+           1,
+           Comp) of
+        N when is_integer(N) ->
+            true;
+        Else ->
+            Else
+    end.

--- a/test/test_handler.erl
+++ b/test/test_handler.erl
@@ -61,6 +61,8 @@ handle_message(<<"hello">>, Actor, State) ->
     {State#state{got_hello=true}, [{unicast, Actor, <<"ehlo">>}, {multicast, <<"hai">>}]};
 handle_message(<<"hai">>, Actor, State = #state{id=Actor}) ->
     {State#state{got_self_hai=true}, []};
+handle_message(<<"unicast: ", Msg/binary>>, Actor, State) ->
+    {State, [{unicast, Actor, Msg}]};
 handle_message(<<"salutations to ", ID/binary>>, Actor, State = #state{id=Actor}) ->
     case list_to_integer(binary_to_list(ID)) of
         Actor ->


### PR DESCRIPTION
change relcast's behavior so that we can `take` more than one value at a time.  I tried to keep the API relatively similar, and some clients might still work by accident, but this should be considered a breaking change.

a precis: `take` now has `/2` and `/3` variants.  you use `take/3` on connect and reconnect, then you can use `take/2` until you run into `not_found` or `pipeline_full` at each dispatch.  Then you need to wait for new messages or acks and try again.

should be fairly simple, but testing it in the context of libp2p seems complex.