### PR TITLE
move relcast to use transactions

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -21,7 +21,8 @@
 
 {deps, [
         lager,
-        rocksdb
+        %%rocksdb
+        {rocksdb, {git, "https://gitlab.com/evanmcc/erlang-rocksdb", {branch, "pevm/add-txn"}}}
        ]
 }.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,12 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0},
- {<<"rocksdb">>,{pkg,<<"rocksdb">>,<<"0.26.2">>},0}]}.
+ {<<"rocksdb">>,
+  {git,"https://gitlab.com/evanmcc/erlang-rocksdb",
+       {ref,"6f7fc2138100d62b068b6d2003ac735e7c71a325"}},
+  0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>},
- {<<"rocksdb">>, <<"73339994D2F0D983E610F04D574D0B2C22B8A6EE5B166AC8308B29B1E5FF61DD">>}]}
+ {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>}]}
 ].

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -783,18 +783,14 @@ round_to_nearest_byte(Bits) ->
 get_mod_state(DB, OldCF, Module, ModuleState0) ->
     case rocksdb:get(DB, OldCF, ?stored_module_state, []) of
         {ok, SerializedModuleState} ->
-            ct:pal("found old"),
             ok = rocksdb:put(DB, ?stored_module_state, SerializedModuleState, []),
             ok = rocksdb:delete(DB, OldCF, ?stored_module_state, []),
             rehydrate(Module, SerializedModuleState, ModuleState0);
         not_found ->
-            ct:pal("not found old"),
             case rocksdb:get(DB, ?stored_module_state, []) of
                 {ok, SerializedModuleState} ->
-                    ct:pal("found new"),
                     rehydrate(Module, SerializedModuleState, ModuleState0);
                 not_found ->
-                    ct:pal("not found new"),
                     ModuleState0
             end
     end.


### PR DESCRIPTION
NB: for this to work right now you'll need to go make _checkouts and then clone https://gitlab.com/evanmcc/erlang-rocksdb there and then switch to the pevm/add-txn branch.

https://gitlab.com/barrel-db/erlang-rocksdb/merge_requests/102 for the status on the transaction changes in the mainline.

The idea here is to only ever write when we have to; currently it's semantically broken, I think that I need to add another sync point to be safe, and then we can change the acks API as a separate change.