### PR TITLE
don't check defers every deliver

### DIFF
--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -387,6 +387,8 @@ open(Actors, Dir0) ->
     %% edge cases.
     application:set_env(relcast, max_defers, ?MAX_DEFERS),
     application:set_env(relcast, pipeline_depth, ?PIPELINE_DEPTH),
+    %% this is not great, but I'm not sure how to get the model right otherwise
+    application:set_env(relcast, defer_count_threshold, 0),
 
     Dir = case Dir0 of
               undefined ->

--- a/rebar.config
+++ b/rebar.config
@@ -21,8 +21,7 @@
 
 {deps, [
         lager,
-        %%rocksdb
-        {rocksdb, {git, "https://gitlab.com/barrel-db/erlang-rocksdb", {branch, "master"}}}
+        rocksdb
        ]
 }.
 

--- a/rebar.config
+++ b/rebar.config
@@ -22,7 +22,7 @@
 {deps, [
         lager,
         %%rocksdb
-        {rocksdb, {git, "https://gitlab.com/evanmcc/erlang-rocksdb", {branch, "pevm/add-txn"}}}
+        {rocksdb, {git, "https://gitlab.com/barrel-db/erlang-rocksdb", {branch, "master"}}}
        ]
 }.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -3,7 +3,7 @@
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0},
  {<<"rocksdb">>,
   {git,"https://gitlab.com/barrel-db/erlang-rocksdb",
-       {ref,"acf4dd2610b15fadd18e217bdf6bf93aace89f1d"}},
+       {ref,"b7d0c2b400916bca09a70480afaab638b7609405"}},
   0}]}.
 [
 {pkg_hash,[

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,12 +1,10 @@
 {"1.1.0",
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0},
- {<<"rocksdb">>,
-  {git,"https://gitlab.com/barrel-db/erlang-rocksdb",
-       {ref,"b7d0c2b400916bca09a70480afaab638b7609405"}},
-  0}]}.
+ {<<"rocksdb">>,{pkg,<<"rocksdb">>,<<"1.1.0">>},0}]}.
 [
 {pkg_hash,[
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
- {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>}]}
+ {<<"lager">>, <<"2FBF823944CAA0FC10DF5EC13F3F047524A249BB32F0D801B7900C9610264286">>},
+ {<<"rocksdb">>, <<"635F7D52C2B3E5399617C080BA5FE30AB255FD5D9D8180FFDD298E11EA1D62F4">>}]}
 ].

--- a/rebar.lock
+++ b/rebar.lock
@@ -2,8 +2,8 @@
 [{<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.6.7">>},0},
  {<<"rocksdb">>,
-  {git,"https://gitlab.com/evanmcc/erlang-rocksdb",
-       {ref,"6f7fc2138100d62b068b6d2003ac735e7c71a325"}},
+  {git,"https://gitlab.com/barrel-db/erlang-rocksdb",
+       {ref,"acf4dd2610b15fadd18e217bdf6bf93aace89f1d"}},
   0}]}.
 [
 {pkg_hash,[

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -558,7 +558,7 @@ stop(Reason, State = #state{module=Module, modulestate=ModuleState})->
         false ->
             ok
     end,
-    rocksdb:transaction_commit(State#state.transaction),
+    catch rocksdb:transaction_commit(State#state.transaction),
     rocksdb:close(State#state.db).
 
 %% @doc Get a representation of the relcast's module state, inbound queue and

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -40,6 +40,8 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(relcast),
+    application:set_env(relcast, defer_count_threshold, -1),
+    application:set_env(relcast, defer_time_threshold, -1),
     Config.
 
 end_per_suite(Config) ->


### PR DESCRIPTION
make it so that we don't check defers every single delivery to save CPU.

this branch also updates rocks and changes how options are passed in so we can finally use universal compaction on column families.