### PR TITLE
break up state into separate keys when desired

### DIFF
--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -109,10 +109,12 @@
 %% State record
 %%====================================================================
 
--record(state, {
+-record(state,
+         {
           db :: rocksdb:db_handle(),
           module :: atom(),
           modulestate :: any(),
+          old_serialized :: undefined | map() | binary(),
           id :: pos_integer(),
           ids :: [pos_integer()],
           last_sent = #{} :: #{pos_integer() => {rocksdb:cf_handle(), binary()} | none},
@@ -133,6 +135,8 @@
           transaction_dirty = false :: boolean(),
           new_defers :: undefined | integer(),  % right now this is just a counter for delivers
           last_defer_check :: undefined | integer(),
+          key_tree :: [any()],
+          write_key_tree :: boolean(),
           db_opts = [] :: [any()],
           write_opts = [] :: [any()]
          }).
@@ -158,6 +162,8 @@
         ]).
 
 -define(stored_module_state, <<"stored_module_state">>).
+-define(stored_key_prefix, <<"stored_key_">>).
+-define(stored_key_tree, <<"stored_key_tree">>).
 
 %% TODO: remove these when fix goes in
 -dialyzer({nowarn_function, [transaction/2]}).
@@ -171,8 +177,10 @@ transaction(A, B) ->
 %% `ActorID' in the group of `ActorIDs' using the callback module `Module'
 %% initialized with `Arguments'. `RelcastOptions' contains configuration options
 %% around the relcast itself, for example the data directory.
--spec start(pos_integer(), [pos_integer(),...], atom(), list(), list()) -> error | {ok, relcast_state()} | {stop, pos_integer(), relcast_state()}.
+-spec start(pos_integer(), [pos_integer(),...], atom(), list(), list()) ->
+                   error | {ok, relcast_state()} | {stop, pos_integer(), relcast_state()}.
 start(ActorID, ActorIDs, Module, Arguments, RelcastOptions) ->
+    ct:pal("starting"),
     DataDir = proplists:get_value(data_dir, RelcastOptions),
     DBOptions0 = db_options(length(ActorIDs)),
     OpenOpts1 = application:get_env(relcast, db_open_opts, []),
@@ -227,23 +235,29 @@ start(ActorID, ActorIDs, Module, Arguments, RelcastOptions) ->
                          end,
     case Module:init(Arguments) of
         {ok, ModuleState0} ->
-            ModuleState = get_mod_state(DB, InboundCF, Module, ModuleState0),
+            {OldSer, ModuleState, KeyTree} = get_mod_state(DB, InboundCF, Module, ModuleState0, WriteOpts),
             LastKeyIn = get_last_key_in(DB, InboundCF),
             LastKeyOut = get_last_key_out(DB, ActiveCF),
             BitFieldSize = round_to_nearest_byte(length(ActorIDs) + 2) - 2, %% two bits for unicast/multicast
+            %% we only want to write the key tree on the initial switchover or an upgrade.
+            %% TODO figure out how to retrigger on upgrade
+            WriteKeyTree = OldSer == undefined,
             State = #state{module = Module,
                            id = ActorID,
                            inbound_cf = InboundCF,
                            active_cf = ActiveCF,
                            ids = ActorIDs,
                            modulestate = ModuleState,
+                           old_serialized = OldSer,
                            db = DB,
                            out_key_count = LastKeyOut + 1,
                            in_key_count = LastKeyIn + 1,
                            epoch = Epoch,
                            bitfieldsize = BitFieldSize,
                            db_opts = DBOptions,
-                           write_opts = WriteOpts},
+                           write_opts = WriteOpts,
+                           write_key_tree = WriteKeyTree,
+                           key_tree = KeyTree},
             {ok, Iter} = rocksdb:iterator(State#state.db, InboundCF, [{iterate_upper_bound, max_inbound_key()}]),
             Defers = build_defer_list(rocksdb:iterator_move(Iter, {seek, min_inbound_key()}), Iter, InboundCF, #{}),
             %% try to deliver any old queued inbound messages
@@ -274,20 +288,16 @@ command(Message, State = #state{module = Module,
             %% write new output messages & update the state atomically
             case handle_actions(Actions, Transaction, State1) of
                 {ok, NewState} ->
-                    Dirty = maybe_serialize(Module, ModuleState,
-                                            NewState#state.modulestate,
-                                            NewState#state.transaction),
-                    case handle_pending_inbound(NewState#state.transaction, maybe_dirty(Dirty, NewState)) of
+                    NewState1 = maybe_serialize(Module, ModuleState, NewState),
+                    case handle_pending_inbound(NewState#state.transaction, NewState1) of
                         {ok, NewerState} ->
                             {Reply, NewerState};
                         {stop, Timeout, NewerState} ->
                             {stop, Reply, Timeout, NewerState}
                     end;
                 {stop, Timeout, NewState} ->
-                    Dirty = maybe_serialize(Module, ModuleState,
-                                            NewState#state.modulestate,
-                                            NewState#state.transaction),
-                    {stop, Reply, Timeout, maybe_dirty(Dirty, NewState)}
+                    NewState1 = maybe_serialize(Module, ModuleState, NewState),
+                    {stop, Reply, Timeout, NewState1}
             end
     end.
 
@@ -709,7 +719,7 @@ handle_message(Key, CF, FromActorID, Message, Transaction, State = #state{module
             defer;
         {NewModuleState, Actions} ->
             %% write new outbound messages, update the state and (if present) delete the message atomically
-            Dirty1 =
+            Dirty =
                 case Key /= undefined of
                     true ->
                         ok = rocksdb:transaction_delete(Transaction, CF, Key),
@@ -719,15 +729,11 @@ handle_message(Key, CF, FromActorID, Message, Transaction, State = #state{module
                 end,
             case handle_actions(Actions, Transaction, State#state{modulestate=NewModuleState}) of
                 {ok, NewState} ->
-                    Dirty2 = maybe_serialize(Module, ModuleState,
-                                             NewState#state.modulestate,
-                                             Transaction),
-                    {ok, maybe_dirty(Dirty1 orelse Dirty2, NewState)};
+                    NewState1 = maybe_serialize(Module, ModuleState, NewState),
+                    {ok, maybe_dirty(Dirty, NewState1)};
                 {stop, Timeout, NewState} ->
-                    Dirty2 = maybe_serialize(Module, ModuleState,
-                                             NewState#state.modulestate,
-                                             Transaction),
-                    {stop, Timeout, maybe_dirty(Dirty1 orelse Dirty2, NewState)}
+                    NewState1 = maybe_serialize(Module, ModuleState, NewState),
+                    {stop, Timeout, maybe_dirty(Dirty, NewState1)}
             end
     end.
 
@@ -833,7 +839,8 @@ round_to_nearest_byte(Bits) ->
             Bits + (8 - Extra)
     end.
 
-get_mod_state(DB, OldCF, Module, ModuleState0) ->
+%% TODO: this whole thing is one way, we might need a downgrade path?
+get_mod_state(DB, OldCF, Module, ModuleState0, WriteOpts) ->
     case rocksdb:get(DB, OldCF, ?stored_module_state, []) of
         {ok, SerializedModuleState} ->
             ok = rocksdb:put(DB, ?stored_module_state, SerializedModuleState, []),
@@ -842,16 +849,37 @@ get_mod_state(DB, OldCF, Module, ModuleState0) ->
         not_found ->
             case rocksdb:get(DB, ?stored_module_state, []) of
                 {ok, SerializedModuleState} ->
-                    rehydrate(Module, SerializedModuleState, ModuleState0);
+                    {SerState, ModState, _} = rehydrate(Module, SerializedModuleState, ModuleState0),
+                    {ok, Txn} = rocksdb:transaction(DB, WriteOpts),
+                    New = Module:serialize(ModState),
+                    KT =
+                        case do_serialize(Module, undefined, New, ?stored_key_prefix, Txn) of
+                            bin ->
+                                bin;
+                            KeyTree ->
+                                ct:pal("keytree ~p ~p ~p ~p", [KeyTree, New, SerState, ModState]),
+                                _ = maybe_write_key_tree(KeyTree, #state{write_key_tree = true,
+                                                                         transaction = Txn}),
+                                ok = rocksdb:transaction_delete(Txn, ?stored_module_state),
+                                KeyTree
+                        end,
+                    rocksdb:transaction_commit(Txn),
+                    {SerState, ModState, KT};
                 not_found ->
-                    ModuleState0
+                    case rocksdb:get(DB, ?stored_key_tree, []) of
+                        {ok, KeyTreeBin} ->
+                            KeyTree = binary_to_term(KeyTreeBin),
+                            do_deserialize(Module, ModuleState0, ?stored_key_prefix, KeyTree, DB);
+                        not_found ->
+                            {undefined, ModuleState0, bin}
+                    end
             end
     end.
 
 rehydrate(Module, SerState, ModuleState0) ->
     OldModuleState = Module:deserialize(SerState),
     {ok, RestoredModuleState} = Module:restore(OldModuleState, ModuleState0),
-    RestoredModuleState.
+    {SerState, RestoredModuleState, bin}.
 
 %% get the maximum key ID used
 get_last_key_in(DB, CF) ->
@@ -1050,11 +1078,114 @@ make_seq(ID, #state{seq_map=SeqMap, ids=A}=State) ->
 reset_seq(ID, #state{seq_map=SeqMap}=State) ->
     State#state{seq_map=maps:remove(ID, SeqMap)}.
 
-maybe_serialize(_Mod, Old, New, _Transaction) when Old == New ->
-    false;
-maybe_serialize(Mod, _Old, New, Transaction) ->
-    ok = rocksdb:transaction_put(Transaction, ?stored_module_state, Mod:serialize(New)),
-    true.
+maybe_serialize(_Mod, Old, #state{modulestate = New} = S) when Old == New ->
+    S;
+maybe_serialize(Mod, _Old, #state{modulestate = New0,
+                                  old_serialized = Old,
+                                  transaction = Transaction} = S) ->
+    New = Mod:serialize(New0),
+    KeyTree = do_serialize(Mod, Old, New, ?stored_key_prefix, Transaction),
+    S1 = maybe_write_key_tree(KeyTree, S),
+    S1#state{old_serialized = New, transaction_dirty = true}.
+
+maybe_write_key_tree(KeyTree, S) when KeyTree == S#state.key_tree->
+    S;
+maybe_write_key_tree(KeyTree, S) ->
+    ct:pal("updating key tree ~p ~p", [S#state.key_tree, KeyTree]),
+    ok = rocksdb:transaction_put(S#state.transaction, ?stored_key_tree,
+                                 term_to_binary(KeyTree, [compressed])),
+    S#state{write_key_tree = false, key_tree = KeyTree}.
+
+old_size(M) when is_map(M) ->
+    maps:size(M);
+old_size(_) ->
+    -1.
+
+do_serialize(Mod, Old, New, Prefix, Transaction) ->
+    case New of
+        State when is_binary(State) ->
+            ok = rocksdb:transaction_put(Transaction, ?stored_module_state, State),
+            bin;
+        StateMap ->
+            S = lists:sort(maps:to_list(StateMap)),
+            SSize = maps:size(StateMap),
+            OSize = old_size(Old),
+            O = case Old of
+                    %% since we're serializing for the first time, we need to make sure that
+                    %% everything gets written out, otherwise we have partial state that
+                    %% won't restore correctly.
+                    BorU when BorU == undefined orelse
+                              is_binary(BorU) ->
+                        lists:map(fun({K, _V}) -> {K, never_ever_match_with_anything} end, S);
+                    _Size when OSize =/= SSize ->
+                        SKeys = maps:keys(StateMap),
+                        OKeys = maps:keys(Old),
+                        Old1 = lists:foldl(fun(L, OM) ->
+                                                   OM#{L => undefined}
+                                           end,
+                                           Old,
+                                           SKeys -- OKeys),
+                        ct:pal("old ~p", [Old1]),
+                        maps:to_list(maps:without(OKeys -- SKeys, Old1));
+                    _ ->
+                        lists:sort(maps:to_list(Old))
+                end,
+            L = lists:zip(S, O),
+            KeyTree =
+                lists:map(
+                  fun({{K, V}, {_, V}}) ->
+                          %% should be a binary
+                          K;
+                     ({{K, V}, {_, OV}}) ->
+                          KeyName = <<Prefix/binary, (atom_to_binary(K, utf8))/binary>>,
+                          case is_map(V) of
+                              true ->
+                                  do_serialize(K, fixup_old_map(OV), V, <<KeyName/binary, "_">>, Transaction);
+                              false ->
+                                  ok = rocksdb:transaction_put(Transaction, KeyName, V),
+                                  K
+                          end
+                  end,
+                  L),
+            [Mod | KeyTree]
+    end.
+
+fixup_old_map(never_ever_match_with_anything) ->
+    undefined;
+fixup_old_map(M) ->
+    M.
+
+%% this needs to return {serstate, restored modstate} I think
+do_deserialize(Mod, NewState, Prefix, KeyTree, RocksDB) ->
+    R = fun Rec(Pfix, [_Top | KT], DB) ->
+                lists:foldl(
+                  fun(K, Acc) when is_atom(K) ->
+                          KeyName = <<Pfix/binary, (atom_to_binary(K, utf8))/binary>>,
+                          Term = case rocksdb:get(DB, KeyName, []) of
+                                     {ok, Bin} ->
+                                         Bin;
+                                     not_found ->
+                                         undefined
+                                 end,
+                          Acc#{K => Term};
+                     (L, Acc) when is_list(L) ->
+                          K = hd(L),
+                          KeyName = <<Pfix/binary, (atom_to_binary(K, utf8))/binary, "_">>,
+                          Acc#{K => Rec(KeyName, L, DB)}
+                  end,
+                  #{},
+                  KT);
+            Rec(_, bin, DB) ->
+                case rocksdb:get(DB, ?stored_module_state, []) of
+                    {ok, Bin} ->
+                        Bin;
+                    not_found ->
+                        not_found
+                end
+        end,
+    Map = R(Prefix, KeyTree, RocksDB),
+    {A, B, _} = rehydrate(Mod, Map, NewState),
+    {A, B, KeyTree}.
 
 maybe_update_state(State, ignore) ->
     State;

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -237,8 +237,6 @@ start(ActorID, ActorIDs, Module, Arguments, RelcastOptions) ->
             LastKeyIn = get_last_key_in(DB, InboundCF),
             LastKeyOut = get_last_key_out(DB, ActiveCF),
             BitFieldSize = round_to_nearest_byte(length(ActorIDs) + 2) - 2, %% two bits for unicast/multicast
-            %% we only want to write the key tree on the initial switchover or an upgrade.
-            %% TODO figure out how to retrigger on upgrade
             State = #state{module = Module,
                            id = ActorID,
                            inbound_cf = InboundCF,
@@ -835,7 +833,6 @@ round_to_nearest_byte(Bits) ->
             Bits + (8 - Extra)
     end.
 
-%% TODO: this whole thing is one way, we might need a downgrade path?
 get_mod_state(DB, OldCF, Module, ModuleState0, WriteOpts) ->
     case rocksdb:get(DB, OldCF, ?stored_module_state, []) of
         {ok, SerializedModuleState} ->
@@ -1147,7 +1144,6 @@ fixup_old_map(never_ever_match_with_anything) ->
 fixup_old_map(M) ->
     M.
 
-%% this needs to return {serstate, restored modstate} I think
 do_deserialize(Mod, NewState, Prefix, KeyTree, RocksDB) ->
     R = fun Rec(Pfix, [_Top | KT], DB) ->
                 lists:foldl(

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -870,16 +870,13 @@ get_mod_state(DB, OldCF, Module, ModuleState0, WriteOpts) ->
                     NewSer = Module:serialize(ModState),
                     case get_key_tree(Module, NewSer) of
                         KeyTree ->
-                            lager:info("state matches ~p", [KeyTree]),
                             {SerState, ModState, KeyTree};
                         bin ->
-                            lager:info("state moved to bin ~p", [KeyTree]),
                             ok = rocksdb:put(DB, ?stored_module_state, NewSer,
                                              [{sync, true}]),
                             _ = rocksdb:delete(DB, ?stored_key_tree, [{sync, true}]),
                             {SerState, ModState, bin};
                         KeyTreeNew ->
-                            lager:info("state didn't match new ~p old ~p", [KeyTree, KeyTreeNew]),
                             ok = rocksdb:put(DB, ?stored_key_tree,
                                              term_to_binary(KeyTreeNew, [compressed]), [{sync, true}]),
                             {SerState, ModState, KeyTree}
@@ -1176,10 +1173,8 @@ do_deserialize(Mod, NewState, Prefix, KeyTree, RocksDB) ->
                           KeyName = <<Pfix/binary, (atom_to_binary(K, utf8))/binary>>,
                           Term = case rocksdb:get(DB, KeyName, []) of
                                      {ok, Bin} ->
-                                         lager:info("~p -> ~p", [KeyName, Bin]),
                                          Bin;
                                      not_found ->
-                                         lager:info("~p -> not_found", [KeyName]),
                                          undefined
                                  end,
                           Acc#{K => Term};

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -257,7 +257,9 @@ start(ActorID, ActorIDs, Module, Arguments, RelcastOptions) ->
             Defers = build_defer_list(rocksdb:iterator_move(Iter, {seek, min_inbound_key()}), Iter, InboundCF, #{}),
             %% try to deliver any old queued inbound messages
             {ok, Transaction} = transaction(DB, WriteOpts),
-            {ok, NewState} = handle_pending_inbound(Transaction, State#state{defers=Defers}),
+            {ok, NewState} = handle_pending_inbound(Transaction,
+                                                    State#state{transaction = Transaction,
+                                                                defers=Defers}),
             ok = rocksdb:transaction_commit(Transaction),
             {ok, Transaction1} = transaction(DB, WriteOpts),
             {ok, NewState#state{transaction = Transaction1}};

--- a/test/handler1-a.er
+++ b/test/handler1-a.er
@@ -1,0 +1,79 @@
+-module(handler1).
+
+%-behavior(relcast).
+
+%% -compile({parse_transform, cth_readable_transform}).
+
+-export([
+         init/1,
+         handle_command/2,
+         handle_message/3,
+         callback_message/3,
+         serialize/1,
+         deserialize/1,
+         restore/2
+        ]).
+
+-record(state, {
+                a :: atom(),
+                b :: atom(),
+                c :: atom(),
+                d :: atom(),
+                e :: atom()
+               }).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_command(populate, State) ->
+    {reply, ok, [], State#state{a=a, b=b, c=c, d=d, e=e}};
+handle_command(populate2, State) ->
+    {reply, ok, [], State#state{a=a1, b=b1, c=c1, d=d1, e=e1}};
+handle_command(get, State) ->
+    {reply, State, [], State};
+handle_command(Msg, _State) ->
+    io:format("handle_call, Msg: ~p", [Msg]),
+    {reply, ok, ignore}.
+
+handle_message(Msg, Actor, State) ->
+    ct:pal("handle_message, Msg: ~p, Actor: ~p~n", [Msg, Actor]),
+    {State, []}.
+
+callback_message(_, _, _) ->
+    ignore.
+
+serialize(#state{a = A,
+                 b = B,
+                 c = C,
+                 d = D,
+                 e = E} = State) ->
+
+    %% figure out how to get CT
+    cthr:pal("Serialize a: ~p~n", [State]),
+    M = #{a => A,
+          b => B,
+          c => C,
+          d => D,
+          e => E},
+    maps:map(fun(_K, V) -> term_to_binary(V) end, M).
+
+deserialize(B) when is_binary(B) ->
+    cthr:pal("Deserialize a bin: ~p~n", [B]),
+    binary_to_term(B);
+deserialize(M) ->
+    cthr:pal("Deserialize a map: ~p~n", [M]),
+    M1 = maps:map(fun(_K, V) -> binary_to_term(V) end, M),
+    #{a := A,
+      b := B,
+      c := C,
+      d := D,
+      e := E} = M1,
+    #state{a = A,
+           b = B,
+           c = C,
+           d = D,
+           e = E}.
+
+restore(OldState, NewState) ->
+    cthr:pal("a OldState: ~p, NewState: ~p~n", [OldState, NewState]),
+    {ok, OldState}.

--- a/test/handler1-b.er
+++ b/test/handler1-b.er
@@ -1,0 +1,95 @@
+-module(handler1).
+
+%-behavior(relcast).
+
+-export([
+         init/1,
+         handle_command/2,
+         handle_message/3,
+         callback_message/3,
+         serialize/1,
+         deserialize/1,
+         restore/2
+        ]).
+
+-record(state, {
+                a :: atom(),
+                b :: atom(),
+                c :: atom(),
+                d :: atom(),
+                e :: atom(),
+                f :: atom(),
+                g :: atom()
+               }).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_command(populate3, State) ->
+    {reply, ok, [], State#state{a=a2, b=b2, c=c2, d=d2, e=e2, f=f2, g=g2}};
+handle_command(get, State) ->
+    {reply, State, [], State};
+handle_command(Msg, _State) ->
+    io:format("handle_call, Msg: ~p", [Msg]),
+    {reply, ok, ignore}.
+
+handle_message(Msg, Actor, State) ->
+    cthr:pal("handle_message, Msg: ~p, Actor: ~p~n", [Msg, Actor]),
+    {State, []}.
+
+callback_message(_, _, _) ->
+    ignore.
+
+serialize(#state{a = A,
+                 b = B,
+                 c = C,
+                 d = D,
+                 e = E,
+                 f = F,
+                 g = G} = State) ->
+    cthr:pal("Serialize b: ~p~n", [State]),
+    M = #{a => A,
+          b => B,
+          c => C,
+          d => D,
+          e => E,
+          f => F,
+          g => G},
+    maps:map(fun(_K, V) -> term_to_binary(V) end, M).
+
+deserialize(B) when is_binary(B) ->
+    cthr:pal("Deserialize b bin: ~p~n", [B]),
+    binary_to_term(B);
+deserialize(M) ->
+    cthr:pal("Deserialize b map: ~p~n", [M]),
+    M1 = maps:map(fun(_K, V) -> binary_to_term(V) end, M),
+    case M1 of
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E,
+          f := F,
+          g := G} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E,
+                   f = F,
+                   g = G};
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E}
+    end.
+
+restore(OldState, NewState) ->
+    cthr:pal("b OldState: ~p, NewState: ~p~n", [OldState, NewState]),
+    {ok, OldState}.

--- a/test/handler1-c.er
+++ b/test/handler1-c.er
@@ -1,0 +1,122 @@
+-module(handler1).
+
+%-behavior(relcast).
+
+-export([
+         init/1,
+         handle_command/2,
+         handle_message/3,
+         callback_message/3,
+         serialize/1,
+         deserialize/1,
+         restore/2
+        ]).
+
+-record(state, {
+                a :: atom(),
+                b :: atom(),
+                c :: atom(),
+                d :: #{},
+                e :: atom(),
+                f :: atom(),
+                g :: atom()
+               }).
+
+-record(dstate, {
+                 a :: atom(),
+                 b :: atom(),
+                 c :: atom()
+                }).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_command(populate4, State) ->
+    {reply, ok, [], State#state{a=a3, b=b3, c=c3, d=#dstate{a=d3a, b=d3b, c=d3c},
+                                e=e3, f=f3, g=g3}};
+handle_command(get, State) ->
+    {reply, State, [], State};
+handle_command(Msg, _State) ->
+    io:format("handle_call, Msg: ~p", [Msg]),
+    {reply, ok, ignore}.
+
+handle_message(Msg, Actor, State) ->
+    cthr:pal("handle_message, Msg: ~p, Actor: ~p~n", [Msg, Actor]),
+    {State, []}.
+
+callback_message(_, _, _) ->
+    ignore.
+
+serialize(#state{a = A,
+                 b = B,
+                 c = C,
+                 d = D,
+                 e = E,
+                 f = F,
+                 g = G} = State) ->
+    cthr:pal("Serialize c: ~p~n", [State]),
+    M = #{a => A,
+          b => B,
+          c => C,
+          d => ser_d(D),
+          e => E,
+          f => F,
+          g => G},
+    maps:map(fun(d, V) -> V;
+                (_K, V) -> term_to_binary(V) end, M).
+
+ser_d(#dstate{a = A,
+              b = B,
+              c = C}) ->
+    D = #{a => A, b => B, c => C},
+    maps:map(fun(_K, V) -> term_to_binary(V) end, D).
+
+deser_d(D) when is_binary(D) ->
+    cthr:pal("got binary ~p", [D]),
+    D1 = binary_to_term(D),
+    #dstate{a = D1, b = D1, c = D1};
+deser_d(#{a := A,
+          b := B,
+          c := C} = D) ->
+    cthr:pal("got map ~p", [D]),
+    #dstate{a = binary_to_term(A),
+            b = binary_to_term(B),
+            c = binary_to_term(C)}.
+
+deserialize(B) when is_binary(B) ->
+    cthr:pal("Deserialize c bin: ~p~n", [B]),
+    binary_to_term(B);
+deserialize(M) ->
+    cthr:pal("Deserialize c map: ~p~n", [M]),
+    M1 = maps:map(fun(d, V) -> deser_d(V);
+                     (_K, V) -> binary_to_term(V) end, M),
+    case M1 of
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E,
+          f := F,
+          g := G} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E,
+                   f = F,
+                   g = G};
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E}
+    end.
+
+restore(OldState, NewState) ->
+    cthr:pal("b OldState: ~p, NewState: ~p~n", [OldState, NewState]),
+    {ok, OldState}.

--- a/test/handler1-d.er
+++ b/test/handler1-d.er
@@ -1,0 +1,102 @@
+-module(handler1).
+
+%-behavior(relcast).
+
+-export([
+         init/1,
+         handle_command/2,
+         handle_message/3,
+         callback_message/3,
+         serialize/1,
+         deserialize/1,
+         restore/2
+        ]).
+
+-record(state, {
+                a :: atom(),
+                b :: atom(),
+                c :: atom(),
+                d :: #{},
+                e :: atom(),
+                f :: atom(),
+                g :: atom()
+               }).
+
+-record(dstate, {
+                 a :: atom(),
+                 b :: atom(),
+                 c :: atom()
+                }).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_command(populate5, State) ->
+    {reply, ok, [], State#state{a=a4, b=b4, c=c4, d=#dstate{a=d4a, b=d4b, c=d4c},
+                                e=e4, f=f4, g=g4}};
+handle_command(get, State) ->
+    {reply, State, [], State};
+handle_command(Msg, _State) ->
+    io:format("handle_call, Msg: ~p", [Msg]),
+    {reply, ok, ignore}.
+
+handle_message(Msg, Actor, State) ->
+    cthr:pal("handle_message, Msg: ~p, Actor: ~p~n", [Msg, Actor]),
+    {State, []}.
+
+callback_message(_, _, _) ->
+    ignore.
+
+serialize(State) ->
+    cthr:pal("Serialize d: ~p~n", [State]),
+    term_to_binary(State).
+
+deser_d(D) when is_binary(D) ->
+    cthr:pal("got binary ~p", [D]),
+    D1 = binary_to_term(D),
+    #dstate{a = D1, b = D1, c = D1};
+deser_d(#{a := A,
+          b := B,
+          c := C} = D) ->
+    cthr:pal("got map ~p", [D]),
+    #dstate{a = binary_to_term(A),
+            b = binary_to_term(B),
+            c = binary_to_term(C)}.
+
+deserialize(B) when is_binary(B) ->
+    cthr:pal("Deserialize d bin: ~p~n", [B]),
+    binary_to_term(B);
+deserialize(M) ->
+    cthr:pal("Deserialize d map: ~p~n", [M]),
+    M1 = maps:map(fun(d, V) -> deser_d(V);
+                     (_K, V) -> binary_to_term(V) end, M),
+    case M1 of
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E,
+          f := F,
+          g := G} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E,
+                   f = F,
+                   g = G};
+        #{a := A,
+          b := B,
+          c := C,
+          d := D,
+          e := E} ->
+            #state{a = A,
+                   b = B,
+                   c = C,
+                   d = D,
+                   e = E}
+    end.
+
+restore(OldState, NewState) ->
+    cthr:pal("b OldState: ~p, NewState: ~p~n", [OldState, NewState]),
+    {ok, OldState}.

--- a/test/handler1.erl
+++ b/test/handler1.erl
@@ -1,0 +1,50 @@
+-module(handler1).
+
+-behavior(relcast).
+
+-export([
+         init/1,
+         handle_command/2,
+         handle_message/3,
+         callback_message/3,
+         serialize/1,
+         deserialize/1,
+         restore/2
+        ]).
+
+-record(state, {
+                a :: atom(),
+                b :: atom(),
+                c :: atom(),
+                d :: atom(),
+                e :: atom()
+               }).
+
+init([]) ->
+    {ok, #state{}}.
+
+handle_command(populate, State) ->
+    {reply, ok, [], State#state{a=a, b=b, c=c, d=d, e=e}};
+handle_command(get, State) ->
+    {reply, State, [], State};
+handle_command(Msg, _State) ->
+    io:format("handle_call, Msg: ~p", [Msg]),
+    {reply, ok, ignore}.
+
+handle_message(Msg, Actor, State) ->
+    ct:pal("handle_message, Msg: ~p, Actor: ~p~n", [Msg, Actor]),
+    {State, []}.
+
+callback_message(_, _, _) ->
+    ignore.
+
+serialize(State) ->
+    ct:pal("Serialize: ~p~n", [State]),
+    term_to_binary(State).
+
+deserialize(Binary) ->
+    ct:pal("Deserialize: ~p~n", [Binary]),
+    binary_to_term(Binary).
+
+restore(OldState, _NewState) ->
+    {ok, OldState}.


### PR DESCRIPTION
we want to write to the disk as little as possible, but we write out the whole state any time any part of it changes.  this pr allows for the state to be optionally broken up into individual keys.

it does this by allowing `serialize/1` callbacks to return a potentially nested map of binaries to be serialized separately by rocksdb.  This allows us to not rewrite portions of the state that seldom change.  This adds complexity on the behavior side, but it's worth it in certain cases for the reduced write throughput.