### PR TITLE
ack control

### DIFF
--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -72,9 +72,13 @@ initial_state() ->
     Inf = maps:from_list([{A, []}
                              || A <- Actors]),
 
+    Ackable = maps:from_list([{A, []}
+                              || A <- Actors]),
+
     #s{actors = Actors,
        rc = undefined,
        inflight = Inf,
+       ackable = Ackable,
        running = true,
        act_st = States}.
 
@@ -139,7 +143,7 @@ postcondition(S, {call, _, take, [_, Actor]}, R) ->
     case R of
         {ok, _Seq, _Acks, Expected, _RC} ->
             true;
-        {Expected, _RC} ->
+        {Expected, _, _RC} ->
             true;
         {ok, _Seq, _Acks, Unexpected, _RC} ->
             {unexpected_take1, Actor, {exp, Expected}, {got, Unexpected},
@@ -366,12 +370,12 @@ filter_old_inflight(InFlight, Epoch) ->
 reset_inf(Actor, Inf) ->
     Inf#{Actor => []}.
 
-extract_state({_, RC}) ->
+extract_state({_, _, RC}) ->
     RC;
 extract_state({ok, _, _, _, RC}) ->
     RC.
 
-extract_inf({_, _}, _, Inf, _, _) ->
+extract_inf({_, _, _}, _, Inf, _, _) ->
     Inf;
 extract_inf({ok, Seq, _Acks, Msg, _RC}, Actor, Inf, Msgs, States) ->
     %% find which epoch this message was from
@@ -479,8 +483,8 @@ ack_all(RC, Actor, States, InFlight) ->
                 false ->
                     RC1 = RC;
                 true ->
-                    {Seq, _Epoch, _Msg} = lists:last(OurInFlight),
-                    {ok, RC1} = relcast:multi_ack(Actor, Seq, RC)
+                    Seqs = [Seq || {Seq, _Epoch, _Msg} <- OurInFlight],
+                    {ok, RC1} = relcast:ack(Actor, Seqs, RC)
             end
     end,
     RC1.

--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -35,6 +35,8 @@
          act_st = #{} :: #{pos_integer() => act()},
          %% TODO should we move in-flight into the actor?
          inflight = #{} :: #{pos_integer() => [{Seq ::  pos_integer(), Epoch :: non_neg_integer(), binary()}]},
+         ackable = #{} :: #{},
+         seqno = 1 :: pos_integer(),
          messages = #{} :: #{{pos_integer(), pos_integer()} => {Epoch :: non_neg_integer(), binary()}},
 
          seq = [] :: [non_neg_integer()],
@@ -92,13 +94,14 @@ command(S) ->
 
        {10, {call, ?M, message,
              [S#s.rc,
+              S#s.seqno,
               oneof(S#s.actors),
               oneof(lists:seq(S#s.current_counter, S#s.current_counter + 2)),
               nat()]}},
        {4, {call, ?M, next_col, [S#s.rc]}}, %% called for model side effects
 
        {10, {call, ?M, seq_message,
-             [S#s.rc, nat()]}},
+             [S#s.rc, S#s.seqno, nat()]}},
 
        {10, {call, ?M, take, [S#s.rc, oneof(S#s.actors)]}},
        {10, {call, ?M, peek, [S#s.rc, oneof(S#s.actors)]}},
@@ -134,11 +137,11 @@ postcondition(S, {call, _, take, [_, Actor]}, R) ->
                end,
 
     case R of
-        {ok, _Seq, Expected, _RC} ->
+        {ok, _Seq, _Acks, Expected, _RC} ->
             true;
         {Expected, _RC} ->
             true;
-        {ok, _Seq, Unexpected, _RC} ->
+        {ok, _Seq, _Acks, Unexpected, _RC} ->
             {unexpected_take1, Actor, {exp, Expected}, {got, Unexpected},
              S#s.messages, S#s.inflight};
         {Unexpected, _RC} ->
@@ -254,16 +257,19 @@ next_state(#s{act_st = States,
         inflight = {call, ?M, deliver_inf, [Actor, Inf]}};
 next_state(S, V, {_, _, take, [_, Actor]}) ->
     S#s{rc = {call, ?M, extract_state, [V]},
-        inflight = {call, ?M, extract_inf, [V, Actor, S#s.inflight, S#s.messages, S#s.act_st]}};
+        inflight = {call, ?M, extract_inf, [V, Actor, S#s.inflight, S#s.messages, S#s.act_st]},
+        ackable = {call, ?M, extract_ack, [V, Actor, S#s.ackable]}};
 next_state(S, _V, {_, _, peek, _}) ->
     S;
 next_state(S, _V, {_, _, in_flight, _}) ->
     S;
 next_state(S, V, {_, _, message, _}) ->
     S#s{rc = {call, erlang, element, [1, V]},
+        seqno = S#s.seqno + 1,
         counters = {call, ?M, update_counters, [V, S#s.counters]}};
-next_state(S, V, {_, _, seq_message, [_, Seq]}) ->
+next_state(S, V, {_, _, seq_message, [_, _, Seq]}) ->
     S#s{rc = {call, erlang, element, [1, V]},
+        seqno = S#s.seqno + 1,
         seq = {call, ?M, update_seq, [Seq, S#s.seq, V]}};
 next_state(S, RC, {_, _, next_col, _}) ->
     S#s{rc = RC,
@@ -362,17 +368,24 @@ reset_inf(Actor, Inf) ->
 
 extract_state({_, RC}) ->
     RC;
-extract_state({ok, _, _, RC}) ->
+extract_state({ok, _, _, _, RC}) ->
     RC.
 
 extract_inf({_, _}, _, Inf, _, _) ->
     Inf;
-extract_inf({ok, Seq, Msg, _RC}, Actor, Inf, Msgs, States) ->
+extract_inf({ok, Seq, _Acks, Msg, _RC}, Actor, Inf, Msgs, States) ->
     %% find which epoch this message was from
     #act{acked = Acked} = maps:get(Actor, States),
     #{Actor := Q} = Inf,
     {Epoch, _Msg} = maps:get({Actor, length(Q)+Acked + 1}, Msgs),
     Inf#{Actor => Q ++ [{Seq, Epoch, Msg}]}.
+
+extract_ack({_, _}, _, Ackable) ->
+    Ackable;
+extract_ack({ok, _Seq, Acks, _Msg, _RC}, Actor, Ackable) ->
+    #{Actor := PriorAcks} = Ackable,
+    NewAcks = PriorAcks ++ Acks,
+    Ackable#{Actor => NewAcks}.
 
 update_counters({_, full}, Cols) ->
     Cols;
@@ -410,7 +423,7 @@ stop_command(RC) ->
     relcast:stop(reason, RC1).
 
 stop_message(RC) ->
-    {stop, 0, RC1} = relcast:deliver(term_to_binary(stop), 1, RC),
+    {stop, 0, RC1} = relcast:deliver(0, term_to_binary(stop), 1, RC),
     relcast:stop(reason, RC1).
 
 command(RC, Actor, Msg) ->
@@ -476,9 +489,9 @@ reset(RC, Actor) ->
     {ok, RC1} = relcast:reset_actor(Actor, RC),
     RC1.
 
-message(RC, FromActor, Col, Val) ->
+message(RC, FromActor, SeqNo, Col, Val) ->
     Msg = term_to_binary({add, Col, Val}),
-    case relcast:deliver(Msg, FromActor, RC) of
+    case relcast:deliver(SeqNo, Msg, FromActor, RC) of
         {ok, RC1} ->
             {RC1, Msg};
         full ->
@@ -489,9 +502,9 @@ next_col(RC) ->
     {ok, RC1} = relcast:command(next_col, RC),
     RC1.
 
-seq_message(RC, Seq) ->
+seq_message(RC, SeqNo, Seq) ->
     Msg = term_to_binary({seq, Seq}),
-    case relcast:deliver(Msg, 1, RC) of
+    case relcast:deliver(SeqNo, Msg, 1, RC) of
         {ok, RC1} ->
             {#state{seq=MySeq}, RC2} = relcast:command(state, RC1),
             {_Ms, InboundQueue, _OutboundQueue} = relcast:status(RC2),

--- a/test/basic_SUITE.erl
+++ b/test/basic_SUITE.erl
@@ -52,7 +52,7 @@ end_per_suite(Config) ->
 basic(_Config) ->
     Actors = lists:seq(1, 3),
     {ok, RC1} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data1"}]),
-    {not_found, _} = relcast:take(2, RC1),
+    {not_found, _, _} = relcast:take(2, RC1),
     {false, _} = relcast:command(is_done, RC1),
     {ok, RC1_2} = relcast:deliver(1, <<"hello">>, 2, RC1),
     {true, _} = relcast:command(is_done, RC1_2),
@@ -70,9 +70,9 @@ basic(_Config) ->
     {ok, Seq3_1, [], <<"hai">>, RC1_8} = relcast:take(3, RC1_7, true),
     %% ack both of the outstanding messages
     {ok, RC1_9} = relcast:ack(2, Seq2, RC1_8),
-    {not_found, _} = relcast:take(2, RC1_9),
+    {not_found, _, _} = relcast:take(2, RC1_9),
     {ok, RC1_10} = relcast:ack(3, Seq3_1, RC1_9),
-    {not_found, _} = relcast:take(2, RC1_10),
+    {not_found, _, _} = relcast:take(2, RC1_10),
     relcast:stop(normal, RC1_10),
     ok.
 
@@ -80,8 +80,8 @@ basic2(_Config) ->
     Actors = lists:seq(1, 3),
     {ok, RC1a} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data13a"}]),
     {ok, RC1b} = relcast:start(2, Actors, test_handler, [2], [{data_dir, "data13b"}]),
-    {not_found, _} = relcast:take(2, RC1a),
-    {not_found, _} = relcast:take(1, RC1b),
+    {not_found, _, _} = relcast:take(2, RC1a),
+    {not_found, _, _} = relcast:take(1, RC1b),
     {ok, RC2a} = relcast:command({init, 2}, RC1a),
     {ok, RC2b} = relcast:command({init, 1}, RC1b),
 
@@ -111,8 +111,8 @@ basic2(_Config) ->
     {ok, RC8a} = relcast:ack(2, SeqA2, RC7a),
     {ok, RC8b} = relcast:ack(2, SeqB2, RC7b),
 
-    {not_found, _} = relcast:take(2, RC8a),
-    {not_found, _} = relcast:take(1, RC8b),
+    {not_found, _, _} = relcast:take(2, RC8a),
+    {not_found, _, _} = relcast:take(1, RC8b),
 
     relcast:stop(normal, RC8a),
     relcast:stop(normal, RC8b),
@@ -121,7 +121,7 @@ basic2(_Config) ->
 stop_resume(_Config) ->
     Actors = lists:seq(1, 3),
     {ok, RC1} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data2"}]),
-    {not_found, _} = relcast:take(2, RC1),
+    {not_found, _, _} = relcast:take(2, RC1),
     {false, _} = relcast:command(is_done, RC1),
     {ok, RC1_2} = relcast:deliver(1, <<"hello">>, 2, RC1),
     {true, _} = relcast:command(is_done, RC1_2),
@@ -151,9 +151,9 @@ stop_resume(_Config) ->
     {ok, Ref5, _, <<"hai">>, RC1_12} = relcast:take(2, RC1_11, true),
     %% ack both of the outstanding messages again
     {ok, RC1_13} = relcast:ack(2, Ref4, RC1_12),
-    {not_found, _} = relcast:take(2, RC1_13),
+    {not_found, _, _} = relcast:take(2, RC1_13),
     {ok, RC1_14} = relcast:ack(3, Ref5, RC1_13),
-    {not_found, _} = relcast:take(2, RC1_14),
+    {not_found, _, _} = relcast:take(2, RC1_14),
     relcast:stop(normal, RC1_14),
     ok.
 
@@ -162,7 +162,7 @@ stop_resume(_Config) ->
 upgrade_stop_resume(_Config) ->
     Actors = lists:seq(1, 3),
     {ok, RC1} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data2a"}]),
-    {not_found, _} = relcast:take(2, RC1),
+    {not_found, _, _} = relcast:take(2, RC1),
     {false, _} = relcast:command(is_done, RC1),
     {ok, RC1_2} = relcast:deliver(1, <<"hello">>, 2, RC1),
     {true, _} = relcast:command(is_done, RC1_2),
@@ -210,9 +210,9 @@ upgrade_stop_resume(_Config) ->
     {ok, Ref5, _, <<"hai">>, RC1_12} = relcast:take(2, RC1_11, true),
     %% ack both of the outstanding messages again
     {ok, RC1_13} = relcast:ack(2, Ref4, RC1_12),
-    {not_found, _} = relcast:take(2, RC1_13),
+    {not_found, _, _} = relcast:take(2, RC1_13),
     {ok, RC1_14} = relcast:ack(3, Ref5, RC1_13),
-    {not_found, _} = relcast:take(2, RC1_14),
+    {not_found, _, _} = relcast:take(2, RC1_14),
     relcast:stop(normal, RC1_14),
     ok.
 
@@ -310,7 +310,7 @@ epochs(_Config) ->
     {Map2, _} = relcast:command(seqmap, RC1_6),
     [{2, 2}] = maps:to_list(Map2),
     %% GC'd outbound data queued from the first epoch
-    {not_found, RC1_7} = relcast:take(2, RC1_6),
+    {not_found, _, RC1_7} = relcast:take(2, RC1_6),
     relcast:stop(normal, RC1_7),
     {ok, CFs} = rocksdb:list_column_families("data5", []),
     ["default", "Inbound", "epoch0000000001"] = CFs,
@@ -347,7 +347,7 @@ epochs_gc(_Config) ->
     {Map2, _} = relcast:command(seqmap, RC1_7),
     [{2, 2}] = maps:to_list(Map2),
     %% the data from the original epoch has been GC'd
-    {not_found, _} = relcast:take(2, RC1_7),
+    {not_found, _, _} = relcast:take(2, RC1_7),
     relcast:stop(normal, RC1_7),
     {ok, CFs} = rocksdb:list_column_families("data6", []),
     ["default", "Inbound", "epoch0000000002"] = CFs,
@@ -376,8 +376,8 @@ callback_message(_Config) ->
     {ok, Ref2, _, <<"greetings to 3">>, RC1_4} = relcast:take(3, RC1_3),
     {ok, RC1_5} = relcast:ack(2, Ref, RC1_4),
     {ok, RC1_6} = relcast:ack(3, Ref2, RC1_5),
-    {not_found, RC1_7} = relcast:take(2, RC1_6),
-    {not_found, RC1_8} = relcast:take(3, RC1_7),
+    {not_found, _, RC1_7} = relcast:take(2, RC1_6),
+    {not_found, _, RC1_8} = relcast:take(3, RC1_7),
     relcast:stop(normal, RC1_8),
     ok.
 
@@ -391,8 +391,8 @@ self_callback_message(_Config) ->
     {ok, Ref2, _, <<"salutations to 3">>, RC1_4} = relcast:take(3, RC1_3),
     {ok, RC1_5} = relcast:ack(2, Ref, RC1_4),
     {ok, RC1_6} = relcast:ack(3, Ref2, RC1_5),
-    {not_found, RC1_7} = relcast:take(2, RC1_6),
-    {not_found, RC1_8} = relcast:take(3, RC1_7),
+    {not_found, _, RC1_7} = relcast:take(2, RC1_6),
+    {not_found, _, RC1_8} = relcast:take(3, RC1_7),
     {true, _} = relcast:command(was_saluted, RC1_8),
     relcast:stop(normal, RC1_8),
     ok.
@@ -400,7 +400,7 @@ self_callback_message(_Config) ->
 pipeline(_Config) ->
     Actors = lists:seq(1, 3),
     {ok, RC1} = relcast:start(1, Actors, test_handler, [1], [{data_dir, "data11"}]),
-    {not_found, _} = relcast:take(2, RC1),
+    {not_found, _, _} = relcast:take(2, RC1),
     {ok, RC2} =
         lists:foldl(fun(Idx, {ok, Acc}) ->
                             relcast:deliver(Idx, <<"unicast: hello - ", (integer_to_binary(Idx))/binary>>, 2, Acc)
@@ -415,13 +415,13 @@ pipeline(_Config) ->
                     [N || N <- lists:seq(1, 18)]),
     {ok, Ref2, _, <<"hello - 19">>, RC4} = relcast:take(2, RC3),
     {ok, Ref3, _, <<"hello - 20">>, RC5} = relcast:take(2, RC4),
-    {pipeline_full, _RC4} = relcast:take(2, RC5),
+    {pipeline_full, _, _RC4} = relcast:take(2, RC5),
     20 = relcast:in_flight(2, RC5),
     %% singly ack the second-to-last message first
     {ok, RC6} = relcast:ack(2, Ref2, RC5),
     19 = relcast:in_flight(2, RC6),
     %% test multi-ack
-    {ok, RC7} = relcast:multi_ack(2, Ref1, RC6),
+    {ok, RC7} = relcast:ack(2, lists:seq(Ref1 - 17, Ref1), RC6),
     1 = relcast:in_flight(2, RC7),
     %% ack the last message singly
     {ok, RC8} = relcast:ack(2, Ref3, RC7),
@@ -439,7 +439,7 @@ pipeline(_Config) ->
                     end,
                     RC8,
                     [N || N <- lists:seq(21, 30)]),
-    {not_found, _} = relcast:take(2, RC9),
+    {not_found, _, _} = relcast:take(2, RC9),
     ok.
 
 write_reduction(_Config) ->

--- a/test/test_handler.erl
+++ b/test/test_handler.erl
@@ -26,6 +26,8 @@ init([ID]) ->
 
 handle_command(next_epoch, State) ->
     {reply, ok, [new_epoch], State};
+handle_command({init, To}, State) ->
+    {reply, ok, [{unicast, To, <<"hello">>}], State};
 handle_command(round, State) ->
     {reply, State#state.round, ignore};
 handle_command(next_round, State) ->


### PR DESCRIPTION
This PR changes the API such that take now returns a list of recieved messages to ack.  Then and only then should they be acked.  This allows us to sync state to disk less often.