### PR TITLE
require that we intentionally create any group

### DIFF
--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -417,7 +417,8 @@ open(Actors, Dir0) ->
               Dir0 ->
                   Dir0
           end,
-    {ok, RC} = relcast:start(1, [1 | Actors], ?M, #state{}, [{data_dir, Dir}]),
+    {ok, RC} = relcast:start(1, [1 | Actors], ?M, #state{}, [{create, true},
+                                                             {data_dir, Dir}]),
     {RC, Dir}.
 
 close(RC) ->


### PR DESCRIPTION
- add a sync point on commands, which are rare, to allow us to better control when we save
- alter the code so that we exit with an error when we don't explicitly create a group so we have better control over when we create