### PR TITLE
first draft of ack resets

### DIFF
--- a/eqc/basic_eqc.erl
+++ b/eqc/basic_eqc.erl
@@ -417,7 +417,8 @@ open(Actors, Dir0) ->
               Dir0 ->
                   Dir0
           end,
-    {ok, RC} = relcast:start(1, [1 | Actors], ?M, #state{}, [{data_dir, Dir}]),
+    %% TODO: add difference between open and reopen
+    {ok, RC} = relcast:start(1, [1 | Actors], ?M, #state{}, [{create, true}, {data_dir, Dir}]),
     {RC, Dir}.
 
 close(RC) ->


### PR DESCRIPTION
we're having some issues with potential ack loss.  it looks like actor resets are the only message that we get from libp2p that something we've sent or acked might not have been delivered, so make a best effort at delivering something when we are reset