### PR TITLE
Make dialyzer happy and fix case export

### DIFF
--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -1011,16 +1011,16 @@ find_next_outbound_(_ActorId, _, Iter, _State, 0, Acc) when Acc /= [] ->
     lists:reverse(Acc);
 find_next_outbound_(_ActorId, {error, _}, Iter, State, _, Acc) ->
     %% try to return the *highest* key we saw, so we can try starting here next time
-    case Acc of
+    Res = case Acc of
         [] ->
-            Res = case rocksdb:iterator_move(Iter, prev) of
-                      {ok, Key, _} ->
-                          {not_found, Key, State#state.active_cf};
-                      _ ->
-                          not_found
-                  end;
+            case rocksdb:iterator_move(Iter, prev) of
+               {ok, Key, _} ->
+                  {not_found, Key, State#state.active_cf};
+               _ ->
+                  not_found
+            end;
         _ ->
-            Res = lists:reverse(Acc)
+            lists:reverse(Acc)
     end,
     rocksdb:iterator_close(Iter),
     Res;


### PR DESCRIPTION
Problem to solve: dialyzer currently blows up when checking relcast because the underlying specs in [erlang-rocksdb](https://gitlab.com/barrel-db/erlang-rocksdb) are not "real" and since they are NIF wrappers, dialyzer has no way to infer what the actual return values from a given function might be.  Also there is a minor linting problem where a return value comes directly from inside of a case statement instead of being captured as the expression's return value.

Solution: Fix the case statement. [Open a PR](https://gitlab.com/barrel-db/erlang-rocksdb/-/merge_requests/143) on erlang-rocksdb to fix the spec issue.