### PR TITLE
Allow relcast to serialize raw erlang terms

### DIFF
--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -1224,7 +1224,7 @@ do_serialize(Mod, Old, New, Prefix, Transaction) ->
                           K;
                      ({{K, V}, {_, OV}}) ->
                           KeyName = get_key_name(Prefix, K),
-                          case is_map(V) of
+                          case is_keytree_map(V) of
                               true ->
                                   do_serialize(K, fixup_old_map(OV), V, <<KeyName/binary, "_">>, Transaction);
                               false when is_binary(V) ->
@@ -1243,6 +1243,11 @@ do_serialize(Mod, Old, New, Prefix, Transaction) ->
                   L),
             [Mod | KeyTree]
     end.
+
+is_keytree_map(M) when is_map(M) ->
+    lists:all(fun is_atom/1, maps:keys(M));
+is_keytree_map(_M) ->
+    false.
 
 get_key_name(Prefix, K) when is_atom(K) ->
     <<Prefix/binary, (atom_to_binary(K, utf8))/binary>>;

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -1245,7 +1245,7 @@ do_serialize(Mod, Old, New, Prefix, Transaction) ->
     end.
 
 is_keytree_map(M) when is_map(M) ->
-    lists:all(fun is_atom/1, maps:keys(M));
+    lists:all(fun(E) -> is_atom(E) orelse is_integer(E) orelse is_binary(E) end, maps:keys(M));
 is_keytree_map(_M) ->
     false.
 

--- a/src/relcast.erl
+++ b/src/relcast.erl
@@ -1261,7 +1261,12 @@ get_key_tree(_, B) when is_binary(B) ->
 get_key_tree(Mod, Map) ->
     KT = lists:map(
            fun({K, V}) when is_map(V)->
-                   get_key_tree(K, V);
+                   case is_keytree_map(V) of
+                       true ->
+                           get_key_tree(K, V);
+                       false ->
+                           K
+                   end;
               ({K, _V}) ->
                    K
            end,

--- a/test/handler1-c.er
+++ b/test/handler1-c.er
@@ -63,6 +63,7 @@ serialize(#state{a = A,
           f => F,
           g => G},
     maps:map(fun(d, V) -> V;
+                (g, V) -> V;
                 (_K, V) -> term_to_binary(V) end, M).
 
 ser_d(#dstate{a = A,
@@ -89,6 +90,7 @@ deserialize(B) when is_binary(B) ->
 deserialize(M) ->
     cthr:pal("Deserialize c map: ~p~n", [M]),
     M1 = maps:map(fun(d, V) -> deser_d(V);
+                     (g, V) when not is_binary(V) -> V;
                      (_K, V) -> binary_to_term(V) end, M),
     case M1 of
         #{a := A,

--- a/test/handler1-d.er
+++ b/test/handler1-d.er
@@ -69,6 +69,7 @@ deserialize(B) when is_binary(B) ->
 deserialize(M) ->
     cthr:pal("Deserialize d map: ~p~n", [M]),
     M1 = maps:map(fun(d, V) -> deser_d(V);
+                     (g, V) when not is_binary(V) -> V;
                      (_K, V) -> binary_to_term(V) end, M),
     case M1 of
         #{a := A,


### PR DESCRIPTION
The goal of this change is to move any needed t2b serialization as far to the edge as possible, so we avoid unnecessary term_to_binary calls when fields don't change AND we also retain binary references at the keytree compare phase. Binary references are important because they allow a much faster equality check for large binaries than a byte-by-byte compare.